### PR TITLE
Default iOS simulator to iPhone X

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "start": "react-native start",
     "android": "react-native run-android",
-    "ios": "react-native run-ios",
+    "ios": "react-native run-ios --simulator=\"iPhone X\"",
     "test": "jest",
     "lint": "./node_modules/.bin/eslint . --ext .js",
     "fixlint": "./node_modules/.bin/eslint . --fix",


### PR DESCRIPTION
Sets the default iOS simulator to iPhone X when running `yarn ios` 💥

## Creator

- [x] Build relevant tests if any apply
- [x] Ensure there are no new warnings (in app AND in storybook)
- [x] Upload an animated GIF showcasing the solution (if it applies)
- [x] Set a relevant reviewer

## Reviewer

- [ ] Review CI build results
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review new stories if any apply
- [ ] Review test coverage: Are all new or changed states tested?
- [ ] Review new test logic
