### PR TITLE
21 (part 5) Typography UIText

### DIFF
--- a/mobile/src/ui/theme/defaultTheme.js
+++ b/mobile/src/ui/theme/defaultTheme.js
@@ -52,39 +52,6 @@ export const colors = {
 export const typography = {
   baseFontSize: 18,
   baseLineHeight: 20,
-  // Old fontstack declaration
-  // fontFamilySans: {
-  //   light: {
-  //     default: 'Colfax-Light',
-  //     italic: 'Colfax-LightItalic',
-  //   },
-  //   regular: {
-  //     default: 'Colfax-Regular',
-  //     italic: 'Colfax-RegularItalic',
-  //   },
-  //   medium: {
-  //     default: 'Colfax-Medium',
-  //     italic: 'Colfax-MediumItalic',
-  //   },
-  //   bold: {
-  //     default: 'Colfax-Bold',
-  //     italic: 'Colfax-BoldItalic',
-  //   },
-  //   black: {
-  //     display: 'Colfax-Black',
-  //     italic: 'Colfax-BlackItalic',
-  //   },
-  // },
-  // fontFamilySerif: {
-  //   regular: {
-  //     default: 'DroidSerif-Regular',
-  //     italic: 'DroidSerif-RegularItalic',
-  //   },
-  //   bold: {
-  //     default: 'DroidSerif-Bold',
-  //     italic: 'DroidSerif-BoldItalic',
-  //   },
-  // },
   ...fontStack,
 };
 

--- a/mobile/src/ui/theme/fontStack/index.android.js
+++ b/mobile/src/ui/theme/fontStack/index.android.js
@@ -31,6 +31,9 @@ const fontStack = {
       italic: 'DroidSerif-BoldItalic',
     },
   },
+  ui: {
+    normal: 'sans-serif',
+  },
 };
 
 export default fontStack;

--- a/mobile/src/ui/theme/fontStack/index.ios.js
+++ b/mobile/src/ui/theme/fontStack/index.ios.js
@@ -31,6 +31,9 @@ const fontStack = {
       italic: 'DroidSerif-BoldItalic',
     },
   },
+  ui: {
+    normal: 'System',
+  },
 };
 
 export default fontStack;

--- a/mobile/src/ui/typography/UIText/UIText.stories.js
+++ b/mobile/src/ui/typography/UIText/UIText.stories.js
@@ -45,7 +45,7 @@ storiesOf('typography/UIText', module)
 
     return (
       <View>
-        <UIText style={border}>Body Text</UIText>
+        <UIText style={border}>UI Text</UIText>
         <UIText style={border}>
           {
             '"You are the only Bible some unbelievers will ever read." – John MacArthur'

--- a/mobile/src/ui/typography/UIText/UIText.stories.js
+++ b/mobile/src/ui/typography/UIText/UIText.stories.js
@@ -48,7 +48,7 @@ storiesOf('typography/UIText', module)
         <UIText style={border}>Body Text</UIText>
         <UIText style={border}>
           {
-            '"True faith means holding nothing\nback. It means putting every\nhope in God\'s fidelity to His Promises." ― Francis Chan'
+            '"You are the only Bible some unbelievers will ever read." – John MacArthur'
           }
         </UIText>
       </View>

--- a/mobile/src/ui/typography/UIText/UIText.stories.js
+++ b/mobile/src/ui/typography/UIText/UIText.stories.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import { View } from 'react-native';
+import { storiesOf } from '@storybook/react-native';
+
+import UIText from './';
+
+storiesOf('typography/UIText', module)
+  .add('Normal', () => (
+    <UIText>
+      {
+        '"True faith means holding nothing back. It means putting every hope in God\'s fidelity to His Promises." ― Francis Chan'
+      }
+    </UIText>
+  ))
+  .add('Bold', () => (
+    <UIText bold>
+      {
+        '"True faith means holding nothing back. It means putting every hope in God\'s fidelity to His Promises." ― Francis Chan'
+      }
+    </UIText>
+  ))
+  .add('Italic', () => (
+    <UIText italic>
+      {
+        '"True faith means holding nothing back. It means putting every hope in God\'s fidelity to His Promises." ― Francis Chan'
+      }
+    </UIText>
+  ))
+  .add('Bold Italic', () => (
+    <UIText bold italic>
+      {
+        '"True faith means holding nothing back. It means putting every hope in God\'s fidelity to His Promises." ― Francis Chan'
+      }
+    </UIText>
+  ))
+  .add('isLoading', () => (
+    <UIText isLoading>
+      {
+        '"True faith means holding nothing back. It means putting every hope in God\'s fidelity to His Promises." ― Francis Chan'
+      }
+    </UIText>
+  ))
+  .add('Border Box – platform testing', () => {
+    const border = { borderWidth: 1, borderStyle: 'solid' };
+
+    return (
+      <View>
+        <UIText style={border}>Body Text</UIText>
+        <UIText style={border}>
+          {
+            '"True faith means holding nothing\nback. It means putting every\nhope in God\'s fidelity to His Promises." ― Francis Chan'
+          }
+        </UIText>
+      </View>
+    );
+  });

--- a/mobile/src/ui/typography/UIText/UIText.stories.js
+++ b/mobile/src/ui/typography/UIText/UIText.stories.js
@@ -8,35 +8,35 @@ storiesOf('typography/UIText', module)
   .add('Normal', () => (
     <UIText>
       {
-        '"True faith means holding nothing back. It means putting every hope in God\'s fidelity to His Promises." ― Francis Chan'
+        '"You are the only Bible some unbelievers will ever read." – John MacArthur'
       }
     </UIText>
   ))
   .add('Bold', () => (
     <UIText bold>
       {
-        '"True faith means holding nothing back. It means putting every hope in God\'s fidelity to His Promises." ― Francis Chan'
+        '"You are the only Bible some unbelievers will ever read." – John MacArthur'
       }
     </UIText>
   ))
   .add('Italic', () => (
     <UIText italic>
       {
-        '"True faith means holding nothing back. It means putting every hope in God\'s fidelity to His Promises." ― Francis Chan'
+        '"You are the only Bible some unbelievers will ever read." – John MacArthur'
       }
     </UIText>
   ))
   .add('Bold Italic', () => (
     <UIText bold italic>
       {
-        '"True faith means holding nothing back. It means putting every hope in God\'s fidelity to His Promises." ― Francis Chan'
+        '"You are the only Bible some unbelievers will ever read." – John MacArthur'
       }
     </UIText>
   ))
   .add('isLoading', () => (
     <UIText isLoading>
       {
-        '"True faith means holding nothing back. It means putting every hope in God\'s fidelity to His Promises." ― Francis Chan'
+        '"You are the only Bible some unbelievers will ever read." – John MacArthur'
       }
     </UIText>
   ))

--- a/mobile/src/ui/typography/UIText/UIText.tests.js
+++ b/mobile/src/ui/typography/UIText/UIText.tests.js
@@ -62,7 +62,7 @@ describe('the UIText component', () => {
       <Providers>
         <UIText accessible={false}>
           {
-            '"True faith means holding nothing back. It means putting every hope in God\'s fidelity to His Promises." ― Francis Chan'
+            '"You are the only Bible some unbelievers will ever read." – John MacArthur'
           }
         </UIText>
       </Providers>

--- a/mobile/src/ui/typography/UIText/UIText.tests.js
+++ b/mobile/src/ui/typography/UIText/UIText.tests.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import Providers from 'TestProviders';
+
+import UIText from './';
+
+describe('the UIText component', () => {
+  it('should render correctly', () => {
+    const tree = renderer.create(
+      <Providers>
+        <UIText>Default UIText text</UIText>
+      </Providers>
+    );
+    expect(tree).toMatchSnapshot();
+  });
+  it('should render as bold', () => {
+    const tree = renderer.create(
+      <Providers>
+        <UIText bold>Bold UIText text</UIText>
+      </Providers>
+    );
+    expect(tree).toMatchSnapshot();
+  });
+  it('should render as italic', () => {
+    const tree = renderer.create(
+      <Providers>
+        <UIText italic>Italic UIText text</UIText>
+      </Providers>
+    );
+    expect(tree).toMatchSnapshot();
+  });
+  it('should render as bold italic', () => {
+    const tree = renderer.create(
+      <Providers>
+        <UIText bold italic>
+          Bold italic UIText text
+        </UIText>
+      </Providers>
+    );
+    expect(tree).toMatchSnapshot();
+  });
+  it('should accept and render passed in styles', () => {
+    const salmon = { color: 'salmon' };
+    const tree = renderer.create(
+      <Providers>
+        <UIText style={salmon}>Salmon text</UIText>
+      </Providers>
+    );
+    expect(tree).toMatchSnapshot();
+  });
+  it('should render a loading state', () => {
+    const tree = renderer.create(
+      <Providers>
+        <UIText isLoading>Default UIText text</UIText>
+      </Providers>
+    );
+    expect(tree).toMatchSnapshot();
+  });
+  it('should accept additional props', () => {
+    const tree = renderer.create(
+      <Providers>
+        <UIText accessible={false}>
+          {
+            '"True faith means holding nothing back. It means putting every hope in God\'s fidelity to His Promises." ― Francis Chan'
+          }
+        </UIText>
+      </Providers>
+    );
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/mobile/src/ui/typography/UIText/__snapshots__/UIText.tests.js.snap
+++ b/mobile/src/ui/typography/UIText/__snapshots__/UIText.tests.js.snap
@@ -1,0 +1,140 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`the UIText component should accept additional props 1`] = `
+<Text
+  accessible={false}
+  allowFontScaling={true}
+  ellipsizeMode="tail"
+  style={
+    Object {
+      "color": "#303030",
+      "fontFamily": "System",
+      "fontSize": 18,
+      "fontStyle": null,
+      "fontWeight": null,
+      "lineHeight": 20,
+    }
+  }
+>
+  "True faith means holding nothing back. It means putting every hope in God's fidelity to His Promises." ― Francis Chan
+</Text>
+`;
+
+exports[`the UIText component should accept and render passed in styles 1`] = `
+<Text
+  accessible={true}
+  allowFontScaling={true}
+  ellipsizeMode="tail"
+  style={
+    Object {
+      "color": "salmon",
+      "fontFamily": "System",
+      "fontSize": 18,
+      "fontStyle": null,
+      "fontWeight": null,
+      "lineHeight": 20,
+    }
+  }
+>
+  Salmon text
+</Text>
+`;
+
+exports[`the UIText component should render a loading state 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "stretch",
+      "backgroundColor": "#dddddd",
+      "borderRadius": 6,
+      "height": 18,
+      "marginVertical": 1,
+      "width": "40%",
+    }
+  }
+/>
+`;
+
+exports[`the UIText component should render as bold 1`] = `
+<Text
+  accessible={true}
+  allowFontScaling={true}
+  bold={true}
+  ellipsizeMode="tail"
+  style={
+    Object {
+      "color": "#303030",
+      "fontFamily": "System",
+      "fontSize": 18,
+      "fontStyle": null,
+      "fontWeight": "700",
+      "lineHeight": 20,
+    }
+  }
+>
+  Bold UIText text
+</Text>
+`;
+
+exports[`the UIText component should render as bold italic 1`] = `
+<Text
+  accessible={true}
+  allowFontScaling={true}
+  bold={true}
+  ellipsizeMode="tail"
+  italic={true}
+  style={
+    Object {
+      "color": "#303030",
+      "fontFamily": "System",
+      "fontSize": 18,
+      "fontStyle": "italic",
+      "fontWeight": "700",
+      "lineHeight": 20,
+    }
+  }
+>
+  Bold italic UIText text
+</Text>
+`;
+
+exports[`the UIText component should render as italic 1`] = `
+<Text
+  accessible={true}
+  allowFontScaling={true}
+  ellipsizeMode="tail"
+  italic={true}
+  style={
+    Object {
+      "color": "#303030",
+      "fontFamily": "System",
+      "fontSize": 18,
+      "fontStyle": "italic",
+      "fontWeight": null,
+      "lineHeight": 20,
+    }
+  }
+>
+  Italic UIText text
+</Text>
+`;
+
+exports[`the UIText component should render correctly 1`] = `
+<Text
+  accessible={true}
+  allowFontScaling={true}
+  ellipsizeMode="tail"
+  style={
+    Object {
+      "color": "#303030",
+      "fontFamily": "System",
+      "fontSize": 18,
+      "fontStyle": null,
+      "fontWeight": null,
+      "lineHeight": 20,
+    }
+  }
+>
+  Default UIText text
+</Text>
+`;

--- a/mobile/src/ui/typography/UIText/__snapshots__/UIText.tests.js.snap
+++ b/mobile/src/ui/typography/UIText/__snapshots__/UIText.tests.js.snap
@@ -16,7 +16,7 @@ exports[`the UIText component should accept additional props 1`] = `
     }
   }
 >
-  "True faith means holding nothing back. It means putting every hope in God's fidelity to His Promises." ― Francis Chan
+  "You are the only Bible some unbelievers will ever read." – John MacArthur
 </Text>
 `;
 

--- a/mobile/src/ui/typography/UIText/index.js
+++ b/mobile/src/ui/typography/UIText/index.js
@@ -1,0 +1,33 @@
+import { Text } from 'react-native';
+import PropTypes from 'prop-types';
+import { compose, pure } from 'recompose';
+
+import styled from 'ui/styled';
+import { withPlaceholder, Typography } from 'ui/Placeholder';
+
+const styles = styled(
+  ({ theme, bold, italic }) => ({
+    fontSize: theme.helpers.rem(1),
+    lineHeight: theme.helpers.verticalRhythm(1, 1),
+    fontFamily: theme.typography.ui.normal,
+    fontStyle: italic ? 'italic' : null,
+    fontWeight: bold ? '700' : null,
+    color: theme.colors.text.primary,
+  }),
+  'UIText'
+);
+
+const UIText = compose(
+  styles,
+  withPlaceholder(Typography, { width: '40%' }),
+  pure
+)(Text);
+
+UIText.propTypes = {
+  bold: PropTypes.bool,
+  italic: PropTypes.bool,
+  isLoading: PropTypes.bool, // display loading placeholder
+  ...Text.propTypes,
+};
+
+export default UIText;


### PR DESCRIPTION
Fixes #21!

This adds a very basic UIText component that renders with system fonts. It only supports a bold (700) weight and italics in the regular font. Future expansion could support thin, light, and medium font family varieties. This component is intended for UI purposes only as a way to make standard UI components feel more native. `theme.typography.sans` and `theme.typography.serif` are branded and to be used in all other places that require expressing said brand.

### iOS
![image](https://user-images.githubusercontent.com/2053547/40989032-9bc2ede2-68ba-11e8-99a0-713d61437a48.png)
### Android
![image](https://user-images.githubusercontent.com/2053547/40989043-a2fafe92-68ba-11e8-90fe-bcce44fe7422.png)

## Creator

- [x] Build relevant tests if any apply
- [x] Ensure there are no new warnings (in app AND in storybook)
- [x] Upload an animated GIF showcasing the solution (if it applies)
- [x] Set a relevant reviewer

## Reviewer

- [ ] Review CI build results
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review new stories if any apply
- [ ] Review test coverage: Are all new or changed states tested?
- [ ] Review new test logic
