### PR TITLE
Now CI implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,13 +24,6 @@ jobs:
 before_deploy: npm install now --no-save
 deploy:
   - provider: script
-    script: cd api && now --token --public $NOW_TOKEN
-    skip_cleanup: true
-    on:
-      all_branches: true
-      condition: $TRAVIS_PULL_REQUEST != false
-      master: false
-  - provider: script
     script: cd api && now --token --public $NOW_TOKEN && now alias --token $NOW_TOKEN
     skip_cleanup: true
     on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ deploy:
     skip_cleanup: true
     on:
       all_branches: true
+      condition: $TRAVIS_PULL_REQUEST != false
       master: false
   - provider: script
     script: cd api && now --token --public $NOW_TOKEN && now alias --token $NOW_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js: '8.11.2'
-cache: yarn
+cache:
+  yarn: true
+  directories:
+    - node_modules
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
 install:
@@ -18,3 +21,16 @@ jobs:
     - stage: test
       script:
         - bash ./scripts/global-npm-script.sh test
+before_deploy: npm install now --no-save
+deploy:
+  - provider: script
+    script: cd api && now --token --public $NOW_TOKEN
+    skip_cleanup: true
+    on:
+      all_branches: true
+      master: false
+  - provider: script
+    script: cd api && now --token --public $NOW_TOKEN && now alias --token $NOW_TOKEN
+    skip_cleanup: true
+    on:
+      master: true

--- a/api/package.json
+++ b/api/package.json
@@ -52,5 +52,9 @@
     "jest": "^23.0.0",
     "jest-fetch-mock": "^1.6.2",
     "nodemon": "^1.17.5"
+  },
+  "now": {
+    "name": "apollos-church-api",
+    "alias": "apollos-church-api.now.sh"
   }
 }


### PR DESCRIPTION
Implements Now into our current CI.

This allows us to build a new version of our API with each PR and a main api help at https://apollos-church-api.now.sh.

## Creator

- [ ] Build relevant tests if any apply
- [ ] Ensure there are no new warnings (in app AND in storybook)
- [ ] Upload an animated GIF showcasing the solution (if it applies)
- [ ] Set a relevant reviewer

## Reviewer

- [ ] Review CI build results
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review new stories if any apply
- [ ] Review test coverage: Are all new or changed states tested?
- [ ] Review new test logic
