### PR TITLE
Improved splash screens

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { createStackNavigator } from 'react-navigation';
 import { Sentry } from 'react-native-sentry';
-
+import SplashScreen from 'react-native-splash-screen';
 import Providers from 'Providers';
 import ContentFeed from 'content-feed';
 import ContentSingle from 'content-single';
@@ -24,10 +24,18 @@ const AppNavigator = createStackNavigator(
   }
 );
 
-const App = () => (
-  <Providers>
-    <AppNavigator />
-  </Providers>
-);
+class App extends Component {
+  componentDidMount() {
+    SplashScreen.hide();
+  }
+
+  render() {
+    return (
+      <Providers>
+        <AppNavigator />
+      </Providers>
+    );
+  }
+}
 
 export default App;

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -138,6 +138,7 @@ android {
 }
 
 dependencies {
+    compile project(':react-native-splash-screen')
     compile project(':react-native-custom-tabs')
     compile project(':react-native-sentry')
     compile project(':react-native-linear-gradient')

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.apolloschurchapp">
 
     <uses-permission android:name="android.permission.INTERNET" />
@@ -9,7 +10,8 @@
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:allowBackup="false"
-      android:theme="@style/AppTheme">
+      android:theme="@style/AppTheme"
+      tools:replace="android:allowBackup">
       <activity
         android:name=".SplashActivity"
         android:theme="@style/SplashTheme"

--- a/mobile/android/app/src/main/java/com/apolloschurchapp/MainActivity.java
+++ b/mobile/android/app/src/main/java/com/apolloschurchapp/MainActivity.java
@@ -1,9 +1,15 @@
 package com.apolloschurchapp;
 
+import android.os.Bundle;
 import com.facebook.react.ReactActivity;
+import org.devio.rn.splashscreen.SplashScreen;
 
 public class MainActivity extends ReactActivity {
-
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        SplashScreen.show(this);
+        super.onCreate(savedInstanceState);
+    }
     /**
      * Returns the name of the main component registered from JavaScript.
      * This is used to schedule rendering of the component.

--- a/mobile/android/app/src/main/java/com/apolloschurchapp/MainApplication.java
+++ b/mobile/android/app/src/main/java/com/apolloschurchapp/MainApplication.java
@@ -3,6 +3,7 @@ package com.apolloschurchapp;
 import android.app.Application;
 
 import com.facebook.react.ReactApplication;
+import org.devio.rn.splashscreen.SplashScreenReactPackage;
 import com.github.droibit.android.reactnative.customtabs.CustomTabsPackage;
 import io.sentry.RNSentryPackage;
 import com.BV.LinearGradient.LinearGradientPackage;
@@ -27,6 +28,7 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
+            new SplashScreenReactPackage(),
             new CustomTabsPackage(),
             new RNSentryPackage(),
             new LinearGradientPackage(),

--- a/mobile/android/app/src/main/res/drawable/background_splash.xml
+++ b/mobile/android/app/src/main/res/drawable/background_splash.xml
@@ -2,7 +2,7 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item
-        android:drawable="@color/deepWater"/>
+        android:drawable="@color/deep_water"/>
 
     <item
         android:width="95.28dp"

--- a/mobile/android/app/src/main/res/layout/launch_screen.xml
+++ b/mobile/android/app/src/main/res/layout/launch_screen.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/deep_water"
+    android:gravity="center">
+    <ImageView
+
+        android:layout_width="95.28dp"
+        android:layout_height="100dp"
+        android:src="@mipmap/splash_icon"
+    />
+</LinearLayout>

--- a/mobile/android/app/src/main/res/layout/launch_screen.xml
+++ b/mobile/android/app/src/main/res/layout/launch_screen.xml
@@ -9,6 +9,7 @@
 
         android:layout_width="95.28dp"
         android:layout_height="100dp"
+        android:layout_marginTop="-24dp"
         android:src="@mipmap/splash_icon"
     />
 </LinearLayout>

--- a/mobile/android/app/src/main/res/values-v21/styles.xml
+++ b/mobile/android/app/src/main/res/values-v21/styles.xml
@@ -11,8 +11,8 @@
         <item name="android:statusBarColor">@color/deep_water</item>
     </style>
 
-    <style name="SplashScreen_SplashTheme" parent="SplashScreen_SplashTheme">
-        <item name="colorPrimaryDark">@color/deep_water</item>
+    <style name="SplashScreenTheme" parent="SplashScreen_SplashTheme">
+        <item name="android:statusBarColor">@color/deep_water</item>
     </style>
 
 </resources>

--- a/mobile/android/app/src/main/res/values-v21/styles.xml
+++ b/mobile/android/app/src/main/res/values-v21/styles.xml
@@ -8,7 +8,11 @@
 
     <style name="SplashTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="android:windowBackground">@drawable/background_splash</item>
-        <item name="android:statusBarColor">@color/deepWater</item>
+        <item name="android:statusBarColor">@color/deep_water</item>
+    </style>
+
+    <style name="SplashScreen_SplashTheme" parent="SplashScreen_SplashTheme">
+        <item name="colorPrimaryDark">@color/deep_water</item>
     </style>
 
 </resources>

--- a/mobile/android/app/src/main/res/values/colors.xml
+++ b/mobile/android/app/src/main/res/values/colors.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="deepWater">#00676D</color>
+    <color name="deep_water">#00676D</color>
     <color name="growth">#17B582</color>
+    <color name="primary_dark">#00676D</color> // react-native-splash-screen requires this naming
 </resources>

--- a/mobile/android/app/src/main/res/values/styles.xml
+++ b/mobile/android/app/src/main/res/values/styles.xml
@@ -10,7 +10,7 @@
     </style>
 
     <style name="SplashScreenTheme" parent="SplashScreen_SplashTheme">
-        <item name="colorPrimaryDark">@color/deep_water</item>
+        <item name="android:windowIsTranslucent">true</item>
     </style>
 
 </resources>

--- a/mobile/android/app/src/main/res/values/styles.xml
+++ b/mobile/android/app/src/main/res/values/styles.xml
@@ -9,4 +9,8 @@
         <item name="android:windowBackground">@drawable/background_splash</item>
     </style>
 
+    <style name="SplashScreenTheme" parent="SplashScreen_SplashTheme">
+        <item name="colorPrimaryDark">@color/deep_water</item>
+    </style>
+
 </resources>

--- a/mobile/android/settings.gradle
+++ b/mobile/android/settings.gradle
@@ -1,4 +1,8 @@
 rootProject.name = 'apolloschurchapp'
+include ':react-native-splash-screen'
+project(':react-native-splash-screen').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-splash-screen/android')
+include ':react-native-splash-screen'
+project(':react-native-splash-screen').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-splash-screen/android')
 include ':react-native-custom-tabs'
 project(':react-native-custom-tabs').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-custom-tabs/android')
 include ':react-native-sentry'

--- a/mobile/ios/apolloschurchapp.xcodeproj/project.pbxproj
+++ b/mobile/ios/apolloschurchapp.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };
@@ -46,6 +45,7 @@
 		5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E9157331DD0AC6500FF2AA8 /* libRCTAnimation.a */; };
 		6F0E81CA54EF40CA99112EDE /* Inter-UI-Italic.otf in Resources */ = {isa = PBXBuildFile; fileRef = 59DE39F3C72047CD86C60CD7 /* Inter-UI-Italic.otf */; };
 		7612D5AA5CCD4D22A445CB18 /* Inter-UI-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 3BF5927ABB634B12BE925DAB /* Inter-UI-Regular.otf */; };
+		78EC54FCEB57433AAC19DA0F /* libSplashScreen.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 69416A0FCE0D4B6FA7395C6A /* libSplashScreen.a */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
 		9593986FB5A14E20848412A5 /* libDBCustomTabs.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 05AC74B95FA44CF5B8170452 /* libDBCustomTabs.a */; };
 		964B930226BC46138853E5FC /* Inter-UI-BlackItalic.otf in Resources */ = {isa = PBXBuildFile; fileRef = 99B08DBB4D174991B3C333C9 /* Inter-UI-BlackItalic.otf */; };
@@ -353,6 +353,13 @@
 			remoteGlobalIDString = 94DDAC5C1F3D024300EED511;
 			remoteInfo = "RNSVG-tvOS";
 		};
+		8289074A20FE49F300C2085C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DDF7E4A93CA746DFAACC5A7B /* SplashScreen.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 3D7682761D8E76B80014119E;
+			remoteInfo = SplashScreen;
+		};
 		832341B41AAA6A8300B99B32 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */;
@@ -422,6 +429,7 @@
 		5BFC2FE2992D47419C5E5702 /* Inter-UI-MediumItalic.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Inter-UI-MediumItalic.otf"; path = "../assets/fonts/Inter-UI-MediumItalic.otf"; sourceTree = "<group>"; };
 		5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTAnimation.xcodeproj; path = "../node_modules/react-native/Libraries/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<group>"; };
 		671138B1198C48EE9932E26F /* DroidSerif-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "DroidSerif-Regular.ttf"; path = "../assets/fonts/DroidSerif-Regular.ttf"; sourceTree = "<group>"; };
+		69416A0FCE0D4B6FA7395C6A /* libSplashScreen.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libSplashScreen.a; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
 		8E5303EACBC24ACD8B862DCD /* Inter-UI-Black.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Inter-UI-Black.otf"; path = "../assets/fonts/Inter-UI-Black.otf"; sourceTree = "<group>"; };
@@ -431,6 +439,7 @@
 		ADBDB91F1DFEBF0600ED6528 /* RCTBlob.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTBlob.xcodeproj; path = "../node_modules/react-native/Libraries/Blob/RCTBlob.xcodeproj"; sourceTree = "<group>"; };
 		C05D7E405DA7437DAD5E414B /* Inter-UI-BoldItalic.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Inter-UI-BoldItalic.otf"; path = "../assets/fonts/Inter-UI-BoldItalic.otf"; sourceTree = "<group>"; };
 		CEFDF76A4BD748A7B33C94F0 /* Inter-UI-Medium.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Inter-UI-Medium.otf"; path = "../assets/fonts/Inter-UI-Medium.otf"; sourceTree = "<group>"; };
+		DDF7E4A93CA746DFAACC5A7B /* SplashScreen.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = SplashScreen.xcodeproj; path = "../node_modules/react-native-splash-screen/ios/SplashScreen.xcodeproj"; sourceTree = "<group>"; };
 		E0F8357B28EC44E2A33820D8 /* libSafariViewManager.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libSafariViewManager.a; sourceTree = "<group>"; };
 		FA234C92A8B945B19B11F509 /* DroidSerif-BoldItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "DroidSerif-BoldItalic.ttf"; path = "../assets/fonts/DroidSerif-BoldItalic.ttf"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -467,6 +476,7 @@
 				1ECFA1807DCE47339E50F699 /* libz.tbd in Frameworks */,
 				A35CC4A401854AE990E8246E /* libSafariViewManager.a in Frameworks */,
 				9593986FB5A14E20848412A5 /* libDBCustomTabs.a in Frameworks */,
+				78EC54FCEB57433AAC19DA0F /* libSplashScreen.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -671,6 +681,7 @@
 				576F749B5CE74F1FBBD197CA /* libRNSentry.a */,
 				E0F8357B28EC44E2A33820D8 /* libSafariViewManager.a */,
 				05AC74B95FA44CF5B8170452 /* libDBCustomTabs.a */,
+				69416A0FCE0D4B6FA7395C6A /* libSplashScreen.a */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";
@@ -680,6 +691,14 @@
 			children = (
 				82728AD720C6F665005B499E /* libRNSVG.a */,
 				82728AD920C6F665005B499E /* libRNSVG-tvOS.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		8289074720FE49F300C2085C /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				8289074B20FE49F300C2085C /* libSplashScreen.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -704,6 +723,7 @@
 				536557AAF7AF41CDB5A24F28 /* RNSentry.xcodeproj */,
 				0B49BF539AA64F54B6A6186F /* SafariViewManager.xcodeproj */,
 				2A9B4DDE12804541B3064F23 /* ReactNativeCustomTabs.xcodeproj */,
+				DDF7E4A93CA746DFAACC5A7B /* SplashScreen.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -963,6 +983,10 @@
 				{
 					ProductGroup = 793D310F20F8F79D00C1A19D /* Products */;
 					ProjectRef = 0B49BF539AA64F54B6A6186F /* SafariViewManager.xcodeproj */;
+				},
+				{
+					ProductGroup = 8289074720FE49F300C2085C /* Products */;
+					ProjectRef = DDF7E4A93CA746DFAACC5A7B /* SplashScreen.xcodeproj */;
 				},
 			);
 			projectRoot = "";
@@ -1256,6 +1280,13 @@
 			remoteRef = 82728AD820C6F665005B499E /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		8289074B20FE49F300C2085C /* libSplashScreen.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libSplashScreen.a;
+			remoteRef = 8289074A20FE49F300C2085C /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		832341B51AAA6A8300B99B32 /* libRCTText.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -1441,12 +1472,14 @@
 					"$(SRCROOT)/../node_modules/react-native-sentry/ios/**",
 					"$(SRCROOT)/../node_modules/react-native-safari-view",
 					"$(SRCROOT)/../node_modules/react-native-custom-tabs/ios/ReactNativeCustomTabs",
+					"$(SRCROOT)/../node_modules/react-native-splash-screen/ios",
 				);
 				INFOPLIST_FILE = apolloschurchappTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				OTHER_LDFLAGS = (
@@ -1470,12 +1503,14 @@
 					"$(SRCROOT)/../node_modules/react-native-sentry/ios/**",
 					"$(SRCROOT)/../node_modules/react-native-safari-view",
 					"$(SRCROOT)/../node_modules/react-native-custom-tabs/ios/ReactNativeCustomTabs",
+					"$(SRCROOT)/../node_modules/react-native-splash-screen/ios",
 				);
 				INFOPLIST_FILE = apolloschurchappTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				OTHER_LDFLAGS = (
@@ -1503,6 +1538,7 @@
 					"$(SRCROOT)/../node_modules/react-native-sentry/ios/**",
 					"$(SRCROOT)/../node_modules/react-native-safari-view",
 					"$(SRCROOT)/../node_modules/react-native-custom-tabs/ios/ReactNativeCustomTabs",
+					"$(SRCROOT)/../node_modules/react-native-splash-screen/ios",
 				);
 				INFOPLIST_FILE = apolloschurchapp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1534,6 +1570,7 @@
 					"$(SRCROOT)/../node_modules/react-native-sentry/ios/**",
 					"$(SRCROOT)/../node_modules/react-native-safari-view",
 					"$(SRCROOT)/../node_modules/react-native-custom-tabs/ios/ReactNativeCustomTabs",
+					"$(SRCROOT)/../node_modules/react-native-splash-screen/ios",
 				);
 				INFOPLIST_FILE = apolloschurchapp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1569,11 +1606,13 @@
 					"$(SRCROOT)/../node_modules/react-native-sentry/ios/**",
 					"$(SRCROOT)/../node_modules/react-native-safari-view",
 					"$(SRCROOT)/../node_modules/react-native-custom-tabs/ios/ReactNativeCustomTabs",
+					"$(SRCROOT)/../node_modules/react-native-splash-screen/ios",
 				);
 				INFOPLIST_FILE = "apolloschurchapp-tvOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				OTHER_LDFLAGS = (
@@ -1607,11 +1646,13 @@
 					"$(SRCROOT)/../node_modules/react-native-sentry/ios/**",
 					"$(SRCROOT)/../node_modules/react-native-safari-view",
 					"$(SRCROOT)/../node_modules/react-native-custom-tabs/ios/ReactNativeCustomTabs",
+					"$(SRCROOT)/../node_modules/react-native-splash-screen/ios",
 				);
 				INFOPLIST_FILE = "apolloschurchapp-tvOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				OTHER_LDFLAGS = (
@@ -1644,11 +1685,13 @@
 					"$(SRCROOT)/../node_modules/react-native-sentry/ios/**",
 					"$(SRCROOT)/../node_modules/react-native-safari-view",
 					"$(SRCROOT)/../node_modules/react-native-custom-tabs/ios/ReactNativeCustomTabs",
+					"$(SRCROOT)/../node_modules/react-native-splash-screen/ios",
 				);
 				INFOPLIST_FILE = "apolloschurchapp-tvOSTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				OTHER_LDFLAGS = (
@@ -1681,11 +1724,13 @@
 					"$(SRCROOT)/../node_modules/react-native-sentry/ios/**",
 					"$(SRCROOT)/../node_modules/react-native-safari-view",
 					"$(SRCROOT)/../node_modules/react-native-custom-tabs/ios/ReactNativeCustomTabs",
+					"$(SRCROOT)/../node_modules/react-native-splash-screen/ios",
 				);
 				INFOPLIST_FILE = "apolloschurchapp-tvOSTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				OTHER_LDFLAGS = (

--- a/mobile/ios/apolloschurchapp/AppDelegate.m
+++ b/mobile/ios/apolloschurchapp/AppDelegate.m
@@ -9,6 +9,7 @@
 
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
+#import "SplashScreen.h"
 #if __has_include(<React/RNSentry.h>)
 #import <React/RNSentry.h> // This is used for versions of react >= 0.40
 #else
@@ -36,6 +37,8 @@ RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
   rootViewController.view = rootView;
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
+  
+  [SplashScreen show];
   return YES;
 }
 

--- a/mobile/ios/apolloschurchapp/Info.plist
+++ b/mobile/ios/apolloschurchapp/Info.plist
@@ -36,7 +36,7 @@
 		</dict>
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string></string>
+	<string/>
 	<key>UIAppFonts</key>
 	<array>
 		<string>DroidSerif-Bold.ttf</string>

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -44,11 +44,14 @@
     "fixlint": "./node_modules/.bin/eslint . --fix",
     "ios": "react-native run-ios --simulator=\"iPhone X\"",
     "lint": "./node_modules/.bin/eslint . --ext .js",
-    "postversion": "react-native-version --never-amend --android android/app/build.gradle --ios ios/",
+    "postversion":
+      "react-native-version --never-amend --android android/app/build.gradle --ios ios/",
     "start": "node ./scripts/get-introspection-data.js && react-native start",
-    "storybook": "rnstl --searchDir ./storybook ./src --pattern \"**/*.stories.js\" && storybook start -p 7007",
+    "storybook":
+      "rnstl --searchDir ./storybook ./src --pattern \"**/*.stories.js\" && storybook start -p 7007",
     "test": "bash ../scripts/test-script.sh",
-    "watch-graphql": "./node_modules/.bin/nodemon --exec \"rm -rf\" ./node_modules/.cache/babel-loader --watch src -e .graphql -q"
+    "watch-graphql":
+      "./node_modules/.bin/nodemon --exec \"rm -rf\" ./node_modules/.cache/babel-loader --watch src -e .graphql -q"
   },
   "jest": {
     "preset": "react-native",
@@ -56,15 +59,9 @@
     "transformIgnorePatterns": [
       "node_modules/(?!((jest-)?react-native|rn-*|react-clone-referenced-element|react-navigation))"
     ],
-    "testMatch": [
-      "<rootDir>/src/**/?(*.)(test|tests).{js,jsx,mjs}"
-    ],
-    "modulePaths": [
-      "<rootDir>/src/"
-    ],
-    "setupFiles": [
-      "./jest.setup.js"
-    ]
+    "testMatch": ["<rootDir>/src/**/?(*.)(test|tests).{js,jsx,mjs}"],
+    "modulePaths": ["<rootDir>/src/"],
+    "setupFiles": ["./jest.setup.js"]
   },
   "dependencies": {
     "apollo-cache-inmemory": "^1.2.2",
@@ -91,6 +88,7 @@
     "react-native-modal-datetime-picker": "^5.1.0",
     "react-native-safari-view": "^2.1.0",
     "react-native-sentry": "^0.38.1",
+    "react-native-splash-screen": "3.0.6",
     "react-native-svg": "^6.3.1",
     "react-navigation": "^2.3.1",
     "recompose": "^0.27.1",
@@ -98,8 +96,6 @@
     "stream": "^0.0.2"
   },
   "rnpm": {
-    "assets": [
-      "assets/fonts"
-    ]
+    "assets": ["assets/fonts"]
   }
 }

--- a/mobile/yarn.lock
+++ b/mobile/yarn.lock
@@ -8122,6 +8122,10 @@ react-native-sentry@^0.38.1:
     "@sentry/wizard" "^0.9.5"
     raven-js "^3.24.2"
 
+react-native-splash-screen@3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/react-native-splash-screen/-/react-native-splash-screen-3.0.6.tgz#c0bbf2c8ae40a313c4c7044f55e569414ff68332"
+
 react-native-storybook-loader@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/react-native-storybook-loader/-/react-native-storybook-loader-1.8.0.tgz#35056d62f01019af8692d540fd404a855464d4f3"


### PR DESCRIPTION
This added a package to handle the transition from the native launch/splash screen to the point at which JS is actually loaded and ready to render something. Without this a white screen will flash after the launch screen as React Native is mounted. It's really just [another bridge in a series of bridges](https://imgflip.com/i/2e8ljv). 

## Creator

- [ ] Build relevant tests if any apply
- [ ] Ensure there are no new warnings (in app AND in storybook)
- [ ] Upload an animated GIF showcasing the solution (if it applies)
- [ ] Set a relevant reviewer
- [ ] Add a line to the changelog documenting the high-level change this PR introduces

## Reviewer

- [ ] Review CI build results
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review new stories if any apply
- [ ] Review test coverage: Are all new or changed states tested?
- [ ] Review new test logic
- [ ] Review the changelog entry
