### PR TITLE
Fix appcenter builds

### DIFF
--- a/packages/apolloschurchapp/appcenter-post-clone.sh
+++ b/packages/apolloschurchapp/appcenter-post-clone.sh
@@ -4,3 +4,6 @@ brew uninstall node@6
 NODE_VERSION="8.11.3"
 curl "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}.pkg" > "$HOME/Downloads/node-installer.pkg"
 sudo installer -store -pkg "$HOME/Downloads/node-installer.pkg" -target "/"
+
+# Appcenter needs a yarn.lock file to exist next to the package.json to detect yarn:
+cp $(pwd)/../../yarn.lock $(pwd)/yarn.lock


### PR DESCRIPTION
Currently, appcenter builds are failing due to two reasons:

1. A late change to #226 removed `yarn.lock` files from our submodules. This is good for yarn workspaces, but appcenter.ms relies on this `yarn.lock` file to exist to detect whether to use yarn or npm. So, during our `pre-build` phase on appcenter, we now copy over a yarn.lock file for it to use.

2. appcenter keeps defaulting the selected `package.json` to the root-level `package.json` (even though there's a setting to change it - it's not saving it). I believe this is a bug on appcenter, and have contacted their support team for help. If they acknowledge that it's a bug, and will fix it, we might be forced to build manually for the short term. If not, I'll have to come up with another solution that I will address in this PR.

Update on above: Appcenter confirmed this sounds like a bug, and has escalated it to their build team. This PR can likely be merged now, but I'm going to wait for one more confirmation from them that we can't do anything NOW to make our automatic builds work

## Creator

- [ ] Build relevant tests if any apply
- [ ] Ensure there are no new warnings (in app AND in storybook)
- [ ] Upload an animated GIF showcasing the solution (if it applies)
- [ ] Set a relevant reviewer
- [ ] PR has a relevant title that adheres to our patch-notes/change-log style

## Reviewer

- [ ] Review CI build results
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review new stories if any apply
- [ ] Review test coverage: Are all new or changed states tested?
- [ ] Review new test logic
- [ ] Review the change-log entry
- [ ] Review that the PR title adheres to our patch-notes/change-log style
