### PR TITLE
Fixed android builds by removing duplicate launchMode definition 

### DIFF
--- a/packages/apolloschurchapp/android/app/src/main/AndroidManifest.xml
+++ b/packages/apolloschurchapp/android/app/src/main/AndroidManifest.xml
@@ -25,7 +25,6 @@
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"
-        android:launchMode="singleTop"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
         android:windowSoftInputMode="adjustResize"
         android:launchMode="singleTask"


### PR DESCRIPTION
## Creator

- [x] Build relevant tests if any apply
- [x] Ensure there are no new warnings (in app AND in storybook)
- [x] Set a relevant reviewer
- [x] PR has a relevant title that adheres to our patch-notes/change-log style

## Reviewer

- [ ] Review CI build results
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review new stories if any apply
- [ ] Review test coverage: Are all new or changed states tested?
- [ ] Review new test logic
- [ ] Review that the PR title adheres to our patch-notes/change-log style
