### PR TITLE
Disable themes on the api side (temporary), removes wild colors seen in app

### DIFF
--- a/packages/apollos-church-api/src/data/content-items/index.js
+++ b/packages/apollos-church-api/src/data/content-items/index.js
@@ -251,11 +251,8 @@ export const defaultContentItemResolvers = {
     return null;
   },
 
-  // This resolver function is temporary, and is just used to get a seed to generate a random theme from
-  theme: (root) => {
-    if (![6, 5, 4].includes(root.contentChannelId)) return null; // todo: don't generate a theme for these content channel ids
-    return root.guid; // todo: this `guid` is just being used as a seed to generate colors for now
-  },
+  theme: () => null, // todo: integrate themes from Rock
+
   isLiked: async ({ id, isLiked }, args, { dataSources }) => {
     if (isLiked != null) return isLiked;
 


### PR DESCRIPTION
Lets temporarily disable themes on the API side. We know the theming system now works, and we can re-implement once we have color values in Rock.

## Creator

- [x] Build relevant tests if any apply
- [ ] Ensure there are no new warnings (in app AND in storybook)
- [ ] Upload an animated GIF showcasing the solution (if it applies)
- [x] Set a relevant reviewer
- [x] PR has a relevant title that adheres to our patch-notes/change-log style

## Reviewer

- [ ] Review CI build results
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review new stories if any apply
- [ ] Review test coverage: Are all new or changed states tested?
- [ ] Review new test logic
- [ ] Review that the PR title adheres to our patch-notes/change-log style
