### PR TITLE
Fixes new package data source package not included in docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ packages/apolloschurchapp
 packages/apollos-church-api/node_modules
 packages/apollos-church-api/.env
 packages/babel-preset-apollos/node_modules
+packages/apollos-rock-apollo-data-source/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM node:8-alpine
 RUN mkdir -p /usr/src/app
 RUN mkdir -p /usr/src/babel-preset-apollos
+RUN mkdir -p /usr/src/apollos-rock-apollo-data-source
 WORKDIR /usr/src/app
 COPY ./packages/apollos-church-api /usr/src/app
 # In the future, this package should come from NPM.
 COPY ./packages/babel-preset-apollos /usr/src/babel-preset-apollos
+COPY ./packages/apollos-rock-apollo-data-source /usr/src/apollos-rock-apollo-data-source
 RUN yarn
 RUN ["yarn", "build"]
 EXPOSE 4000


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

I forgot to setup Docker with the new rock-apollo-data-source-package. This configures the Dockerfile so it copies over the package into the correct folder.

### What design trade-offs/decisions were made?

These packages should be automatically included. This is a temporary fix so we can deploy again, but we should be able to automatically include new packages using a file glob or something similar. 

### How do I test this PR?

`docker build --no-cache="true" -t apolloschurchapp .`

### What automated tests did you write?

n/a

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [x] Read through the "Files changed" tab _very carefully_
- [x] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [x] How might we make this easier for someone else to understand?
- [x] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
