### PR TITLE
Remove kexec to fix docker builds

### DIFF
--- a/packages/apollos-church-api/package.json
+++ b/packages/apollos-church-api/package.json
@@ -28,8 +28,8 @@
     "testEnvironment": "node"
   },
   "dependencies": {
-    "@apolloschurch/rock-apollo-data-source": "file:../apollos-rock-apollo-data-source",
     "@apolloschurch/config": "file:../apollos-config",
+    "@apolloschurch/rock-apollo-data-source": "file:../apollos-rock-apollo-data-source",
     "analytics-node": "^3.3.0",
     "apollo-datasource-rest": "0.1.1",
     "apollo-server": "^2.0.5",
@@ -59,7 +59,6 @@
     "coveralls": "3.0.1",
     "jest": "23.0.0",
     "jest-fetch-mock": "1.6.2",
-    "kexec": "^3.0.0",
     "nodemon": "1.17.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10255,13 +10255,6 @@ jws@^3.1.5:
     jwa "^1.1.5"
     safe-buffer "^5.0.1"
 
-kexec@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/kexec/-/kexec-3.0.0.tgz#0ef4aa9d3caa26180c11a10075ac1fce2681e36c"
-  integrity sha1-DvSqnTyqJhgMEaEAdawfziaB42w=
-  dependencies:
-    nan "^2.4.0"
-
 keycode@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.2.0.tgz#3d0af56dc7b8b8e5cba8d0a97f107204eec22b04"
@@ -11398,11 +11391,6 @@ mute-stream@0.0.7, mute-stream@~0.0.4:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
-
-nan@^2.4.0:
-  version "2.11.1"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.1.tgz#90e22bccb8ca57ea4cd37cc83d3819b52eea6766"
-  integrity sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==
 
 nan@^2.9.2:
   version "2.10.0"


### PR DESCRIPTION
## DESCRIPTION

I added this package to help `babel-node` stop leaving ghost processes, but it breaks the docker container. If you still are running into issues with ghost processes, you can `yarn global add kexec` 
## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
