### PR TITLE
tweak nuke scripts to better remove `node_modules` folders

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "preversion": "./scripts/update-change-log.sh",
     "publish-schema": "./node_modules/.bin/apollo schema:publish --endpoint=\"https://apollos-church-api.now.sh\" --key=$ENGINE_API_KEY",
     "deploy": "now --public --team apolloschurch --token $NOW_TOKEN --docker && now alias --team apolloschurch --token $NOW_TOKEN && now rm apollos-church-api --team apolloschurch --safe --yes --token $NOW_TOKEN && npm run publish-schema",
-    "nuke": "yarn nuke:node && yarn cache clean && yarn && yarn nuke:cache",
-    "nuke:node": "./scripts/boom.sh && ./node_modules/.bin/lerna exec -- rm -rf ./node_modules",
+    "nuke": "./scripts/boom.sh && yarn nuke:node && yarn nuke:cache",
+    "nuke:node": "rm -rdf ./node_modules packages/*/node_modules && yarn cache clean && yarn",
     "nuke:cache": "watchman watch-del-all && ./node_modules/.bin/lerna run start --scope apolloschurchapp --stream -- --reset-cache",
     "postinstall": "lerna run build"
   },


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Improves the nuke script by not using lerna to delete node_modules folders. This makes sure we are actually clearing any left over node_modules folders from switching branches, and the root-level folder.

### What design trade-offs/decisions were made?

### How do I test this PR?

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
