### PR TITLE
Query by Person Alias

### DIFF
--- a/packages/apollos-church-api/src/data/people/data-source.js
+++ b/packages/apollos-church-api/src/data/people/data-source.js
@@ -16,6 +16,20 @@ export default class Person extends RockApolloDataSource {
       .filter(`Email eq '${email}'`)
       .get();
 
+  getFromAlias = async (alias) => {
+    const _ids = await this.get(`/PersonAlias?$filter=Guid%20eq%20(guid'${alias}')&$select=PersonId`);
+
+    if (!_ids) throw new Error('Invalid Person Alias');
+
+    const _id = _ids[0].personId;
+
+    if (_id) {
+      return await this.get(`/People/${_id}`);
+    }
+
+    return null;
+  }
+
   // fields is an array of objects matching the pattern
   // [{ field: String, value: String }]
   updateProfile = async (fields) => {


### PR DESCRIPTION
In Rock Content Channels, People records are referenced by a Person Alias. The query "getFromAlias" lets us get a Person record from the Alias GUID.

Quick Note: I didn't use the "getFromId" in the return because it wasn't an async function and kept returning an empty object, which is why I opted to just write out the query by hand

## DESCRIPTION

### What does this PR do, or why is it needed?

### What design trade-offs/decisions were made?

### How do I test this PR?

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
