### PR TITLE
Fixes Unseen Content Like Button Crash

### DIFF
--- a/packages/apolloschurchapp/src/ui/LikeButton/LikeButton.tests.js
+++ b/packages/apolloschurchapp/src/ui/LikeButton/LikeButton.tests.js
@@ -61,4 +61,54 @@ describe('the LikeButton component', () => {
     //     );
     //     expect(tree).toMatchSnapshot();
   });
+  it('should render when loading', () => {
+    //     const updateLikeEntity = {
+    //       request: {
+    //         query: gql`
+    //           mutation updateLikeEntity($itemId: ID!, $operation: LIKE_OPERATION!) {
+    //             updateLikeEntity(
+    //               input: { nodeId: $itemId, operation: $operation }
+    //             ) {
+    //               id
+    //               operation
+    //               interactionDateTime
+    //             }
+    //           }
+    //         `,
+    //         variables: {
+    //           itemId: 'asdf',
+    //           operation: 'Like',
+    //         },
+    //       },
+    //       result: {
+    //         data: {
+    //           node: { isLiked: true },
+    //         },
+    //       },
+    //     };
+    //     const getLikedContentItem = {
+    //       request: {
+    //         query: gql`
+    //           query getLikedContentItem($itemId: ID!) {
+    //             node(id: $itemId) {
+    //               ... on ContentItem {
+    //                 id
+    //                 isLiked
+    //               }
+    //             }
+    //           }
+    //         `,
+    //         variables: {
+    //           itemId: 'asdf',
+    //         },
+    //       },
+    //       result: null,
+    //     };
+    //     const tree = renderer.create(
+    //       <Providers mocks={[updateLikeEntity, getLikedContentItem]}>
+    //         <LikeButton itemId={'asdf'} />
+    //       </Providers>
+    //     );
+    //     expect(tree).toMatchSnapshot();
+  });  
 });

--- a/packages/apolloschurchapp/src/ui/LikeButton/LikeButton.tests.js
+++ b/packages/apolloschurchapp/src/ui/LikeButton/LikeButton.tests.js
@@ -110,5 +110,5 @@ describe('the LikeButton component', () => {
     //       </Providers>
     //     );
     //     expect(tree).toMatchSnapshot();
-  });  
+  });
 });

--- a/packages/apolloschurchapp/src/ui/LikeButton/index.js
+++ b/packages/apolloschurchapp/src/ui/LikeButton/index.js
@@ -25,7 +25,12 @@ GetLikeData.propTypes = {
   children: PropTypes.func.isRequired,
 };
 
-const UpdateLikeStatus = ({ itemId, item, isLiked, children }) => (
+const UpdateLikeStatus = ({
+  itemId,
+  item = { __typename: null },
+  isLiked,
+  children,
+}) => (
   <Mutation
     mutation={updateLikeEntity}
     optimisticResponse={{


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
Discovered in the Christ Fellowship app, if a ContentItem appears first as a sibling content item, and is tapped on the by the user, and that item has not appeared in the app before, the app throws an error. We need to provide a default safe value for `__typename` to fix this issue.

### What design trade-offs/decisions were made?
n/a

### How do I test this PR?
Can't reproduce in the ApollosChurchApp because all content items are included in the home query and are thus already cached. 

### What automated tests did you write?
n/a

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
