### PR TITLE
Removes the validation requirement to select save button

### DIFF
--- a/packages/apolloschurchapp/src/user-settings/ChangePassword.js
+++ b/packages/apolloschurchapp/src/user-settings/ChangePassword.js
@@ -67,7 +67,7 @@ class ChangePassword extends PureComponent {
       <SafeAreaView>
         <PaddedView>
           <Button
-            disabled={!props.isValid || props.isSubmitting}
+            disabled={props.isSubmitting}
             onPress={props.handleSubmit}
             title="Save"
             loading={props.isSubmitting}


### PR DESCRIPTION
## DESCRIPTION

Currently, if the 2 passwords don't match on the change password form then the `save` button is disabled. The messaging describing the validation is held in the `onSubmit` method.

### What does this PR do, or why is it needed?

This allows the user to submit the form and have the messaging indicating that the 2 passwords don't match to appear.

### What design trade-offs/decisions were made?

The only difference is that the user is able to submit if there is validation errors. However, this is then caught `onSubmit`.

### How do I test this PR?

Navigate to the user settings and try to change your password.

### What automated tests did you write?

None

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
