### PR TITLE
Adds PersonalDevices dataSource and attaches PersonalDevices to OneSignal.

### DIFF
--- a/packages/apollos-church-api/src/data/index.js
+++ b/packages/apollos-church-api/src/data/index.js
@@ -17,8 +17,12 @@ import {
   ContentChannel,
   Sharable,
   Auth,
+  PersonalDevice,
 } from '@apollosproject/data-connector-rock';
 import * as Theme from './theme';
+
+// This module is used to attach Rock User updating to the OneSignal module.
+import * as OneSignalWithRock from './oneSignalWithRock';
 
 const data = {
   Followings,
@@ -48,6 +52,8 @@ const data = {
   MediaContentItem: {
     dataSource: ContentItem.dataSource,
   }, // alias
+  PersonalDevice,
+  OneSignalWithRock,
 };
 
 const { dataSources, resolvers, schema, context } = createApolloServerConfig(

--- a/packages/apollos-church-api/src/data/index.js
+++ b/packages/apollos-church-api/src/data/index.js
@@ -22,6 +22,7 @@ import {
 import * as Theme from './theme';
 
 // This module is used to attach Rock User updating to the OneSignal module.
+// This module includes a Resolver that overides a resolver defined in `OneSignal`
 import * as OneSignalWithRock from './oneSignalWithRock';
 
 const data = {

--- a/packages/apollos-church-api/src/data/oneSignalWithRock.js
+++ b/packages/apollos-church-api/src/data/oneSignalWithRock.js
@@ -1,0 +1,20 @@
+/* eslint-disable import/prefer-default-export */
+
+export const resolver = {
+  Mutation: {
+    updateUserPushSettings: async (root, { input }, { dataSources }) => {
+      // register the changes w/ one signal
+      const returnValue = await dataSources.OneSignal.updatePushSettings(input);
+
+      // if the pushProviderUserId is changing, we need ot register the device with rock.
+      if (input.pushProviderUserId != null) {
+        await dataSources.PersonalDevice.addPersonalDevice({
+          pushId: input.pushProviderUserId,
+        });
+      }
+
+      // return the original return value (which is currentPerson)
+      return returnValue;
+    },
+  },
+};

--- a/packages/apollos-data-connector-onesignal/src/__tests__/resolver.tests.js
+++ b/packages/apollos-data-connector-onesignal/src/__tests__/resolver.tests.js
@@ -24,7 +24,9 @@ describe('OneSignal', () => {
     const rootValue = {};
 
     const put = jest.fn();
-    const getCurrentPerson = jest.fn(() => Promise.resolve({ id: 'user123' }));
+    const getCurrentPerson = jest.fn(() =>
+      Promise.resolve({ primaryAliasId: 'user123', id: 'user123' })
+    );
     const Auth = { getCurrentPerson };
 
     context.dataSources.OneSignal.put = put;

--- a/packages/apollos-data-connector-onesignal/src/data-source.js
+++ b/packages/apollos-data-connector-onesignal/src/data-source.js
@@ -21,7 +21,7 @@ export default class OneSignal extends RESTDataSource {
     if (pushProviderUserId != null) {
       await this.updateExternalUserId({
         playerId: pushProviderUserId,
-        userId: currentUser.id,
+        userId: currentUser.primaryAliasId,
       });
     }
     return currentUser;

--- a/packages/apollos-data-connector-rock/src/index.js
+++ b/packages/apollos-data-connector-rock/src/index.js
@@ -7,6 +7,7 @@ import * as Sharable from './sharable';
 import * as Person from './people';
 import * as Family from './family';
 import * as Auth from './auth';
+import * as PersonalDevice from './personal-devices';
 
 export {
   Followings,
@@ -18,4 +19,5 @@ export {
   Person,
   Family,
   Auth,
+  PersonalDevice,
 };

--- a/packages/apollos-data-connector-rock/src/personal-devices/__tests__/__snapshots__/data-source.tests.js.snap
+++ b/packages/apollos-data-connector-rock/src/personal-devices/__tests__/__snapshots__/data-source.tests.js.snap
@@ -18,6 +18,7 @@ exports[`Personal device data source must post a user's device to Rock 2`] = `
 [MockFunction] {
   "calls": Array [
     Array [
+      "/PersonalDevices",
       Object {
         "DeviceRegistrationId": "somepushid",
         "NotificationsEnabled": 1,

--- a/packages/apollos-data-connector-rock/src/personal-devices/__tests__/__snapshots__/data-source.tests.js.snap
+++ b/packages/apollos-data-connector-rock/src/personal-devices/__tests__/__snapshots__/data-source.tests.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Personal device data source must exit early if a device is found 1`] = `
+Object {
+  "primaryAliasId": 123,
+}
+`;
+
+exports[`Personal device data source must exit early if a device is found 2`] = `[MockFunction]`;
+
+exports[`Personal device data source must post a user's device to Rock 1`] = `
+Object {
+  "primaryAliasId": 123,
+}
+`;
+
+exports[`Personal device data source must post a user's device to Rock 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Object {
+        "DeviceRegistrationId": "somepushid",
+        "NotificationsEnabled": 1,
+        "PersonAliasId": 123,
+        "PersonalDeviceTypeValueId": 671,
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;

--- a/packages/apollos-data-connector-rock/src/personal-devices/__tests__/data-source.tests.js
+++ b/packages/apollos-data-connector-rock/src/personal-devices/__tests__/data-source.tests.js
@@ -1,0 +1,61 @@
+import ApollosConfig from '@apollosproject/config';
+import { AuthenticationError } from 'apollo-server';
+import DataSource from '../data-source';
+import { buildGetMock } from '../../test-utils';
+
+ApollosConfig.loadJs({
+  ROCK: {
+    API_URL: 'https://apollosrock.newspring.cc/api',
+    API_TOKEN: 'some-rock-token',
+    IMAGE_URL: 'https://apollosrock.newspring.cc/GetImage.ashx',
+  },
+});
+
+const buildDataSource = (Auth) => {
+  const dataSource = new DataSource();
+  dataSource.context = { dataSources: { Auth } };
+  return dataSource;
+};
+
+const AuthMock = { getCurrentPerson: () => ({ primaryAliasId: 123 }) };
+
+describe('Personal device data source', () => {
+  it("must post a user's device to Rock", async () => {
+    const dataSource = buildDataSource(AuthMock);
+    dataSource.get = buildGetMock([], dataSource);
+    dataSource.post = buildGetMock('123', dataSource);
+
+    const result = await dataSource.addPersonalDevice({ pushId: 'somepushid' });
+    expect(result).toMatchSnapshot();
+    expect(dataSource.post).toMatchSnapshot();
+  });
+  it('must exit early if a device is found', async () => {
+    const dataSource = buildDataSource(AuthMock);
+    dataSource.get = buildGetMock([{ Id: 'some device' }], dataSource);
+    dataSource.post = buildGetMock('123', dataSource);
+
+    const result = await dataSource.addPersonalDevice({ pushId: 'somepushid' });
+    expect(result).toMatchSnapshot();
+    expect(dataSource.post).toMatchSnapshot();
+  });
+  it('must raise an error without a pushId', async () => {
+    const dataSource = buildDataSource(AuthMock);
+    dataSource.get = buildGetMock([], dataSource);
+    await expect(
+      dataSource.addPersonalDevice({
+        pushId: null,
+      })
+    ).rejects.toThrow();
+  });
+  it('raise an error without a logged in user', async () => {
+    const dataSource = buildDataSource({
+      getCurrentPerson: () => throw new AuthenticationError(),
+    });
+    dataSource.get = buildGetMock([], dataSource);
+    await expect(
+      dataSource.addPersonalDevice({
+        pushId: 'somepushid',
+      })
+    ).rejects.toThrow();
+  });
+});

--- a/packages/apollos-data-connector-rock/src/personal-devices/data-source.js
+++ b/packages/apollos-data-connector-rock/src/personal-devices/data-source.js
@@ -17,7 +17,7 @@ export default class PersonalDevices extends RockApolloDataSource {
     // if we already have a device, shortcut the function;
     if (existing.length) return currentUser;
 
-    await this.post({
+    await this.post('/PersonalDevices', {
       PersonAliasId: currentUser.primaryAliasId,
       DeviceRegistrationId: pushId,
       PersonalDeviceTypeValueId: 671, // `mobile` device type

--- a/packages/apollos-data-connector-rock/src/personal-devices/data-source.js
+++ b/packages/apollos-data-connector-rock/src/personal-devices/data-source.js
@@ -1,0 +1,29 @@
+import RockApolloDataSource from '@apollosproject/rock-apollo-data-source';
+
+export default class PersonalDevices extends RockApolloDataSource {
+  resource = 'PersonalDevices';
+
+  async addPersonalDevice({ pushId }) {
+    if (!pushId) {
+      throw new Error(
+        'You must supply a `pushId` to the addPersonalDevice function'
+      );
+    }
+    const existing = await this.request()
+      .filter(`DeviceRegistrationId eq '${pushId}'`)
+      .get();
+
+    const currentUser = await this.context.dataSources.Auth.getCurrentPerson();
+    // if we already have a device, shortcut the function;
+    if (existing.length) return currentUser;
+
+    await this.post({
+      PersonAliasId: currentUser.primaryAliasId,
+      DeviceRegistrationId: pushId,
+      PersonalDeviceTypeValueId: 671, // `mobile` device type
+      NotificationsEnabled: 1,
+    });
+
+    return currentUser;
+  }
+}

--- a/packages/apollos-data-connector-rock/src/personal-devices/index.js
+++ b/packages/apollos-data-connector-rock/src/personal-devices/index.js
@@ -1,0 +1,4 @@
+/* eslint-disable import/prefer-default-export */
+import dataSource from './data-source';
+
+export { dataSource };


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Rock needs some record of a PersonalDevice in order to create the communication transport in Rock. This PR does two things:
- Adds a PersonalDevice data source to write to the PersonalDevice table.
- Adds a resolver override to attach the PersonalDevice rock specific code to the OneSignal specific code. 

I didn't want to add Rock specific code to the OneSignal Source, nor add OneSignal code to the Rock source, so I created a "resolver override" that fires off the OneSignal function first (which updates a value in Rock), and then fires the Rock function to add a PersonalDevice to Rock for a user. 

 
### What design trade-offs/decisions were made?
n/a

### How do I test this PR?
Hard to test before client front end is merged. I tested manually by ...

1. Login via graphql playground and get a token.
2. Check for your player ID in the OneSignal player list
3. called the `updateUserPushSettings` mutation, passing in my token from step 1 and my player id from step 2.
4. Checked OneSignal and made sure my PlayerId was attached to my RockID
5. Checked Rock and made sure there was a new record created w/ my User AliasId and my PushEnabled: true

### What automated tests did you write?

Unit tests over new DatSource. 

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes 
- [x] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
