### PR TITLE
Mounted ApolloServer on root path

### DIFF
--- a/packages/apollos-church-api/src/server.js
+++ b/packages/apollos-church-api/src/server.js
@@ -44,6 +44,7 @@ const apolloServer = new ApolloServer({
 const app = express();
 
 apolloServer.applyMiddleware({ app });
+apolloServer.applyMiddleware({ app, path: '/' });
 applyServerMiddleware({ app, dataSources, context });
 
 export default app;


### PR DESCRIPTION
## DESCRIPTION

ApolloServer does this by default, but not when you use `applyMiddleware`. This unintentional change in configuration has caused headaches, and mounting on root will reproduce the same configuration as ApolloServer.

### What does this PR do, or why is it needed?


### What design trade-offs/decisions were made?

### How do I test this PR?

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
