### PR TITLE
Fixes user campus not returning location

### DIFF
--- a/packages/apollos-data-connector-rock/src/campuses/__tests__/__snapshots__/resolver.tests.js.snap
+++ b/packages/apollos-data-connector-rock/src/campuses/__tests__/__snapshots__/resolver.tests.js.snap
@@ -189,6 +189,8 @@ Object {
       "profile": Object {
         "campus": Object {
           "id": "Campus:559b23fd0aa90e81b1c023e72e230fa1",
+          "latitude": 1.1,
+          "longitude": 2.2,
           "name": "the best campus",
         },
       },
@@ -200,7 +202,7 @@ Object {
 exports[`Campus gets current user's campus 2`] = `
 Array [
   Array [
-    "/Groups/GetFamilies/51?loadAttributes=expanded&%24expand=Campus&%24top=1",
+    "/Groups/GetFamilies/51?loadAttributes=expanded&%24expand=Campus%2CCampus%2FLocation%2CCampus%2FLocation%2FImage&%24top=1",
     Object {},
     Object {},
   ],
@@ -222,7 +224,7 @@ Object {
 exports[`Campus returns null if a user has no campus 2`] = `
 Array [
   Array [
-    "/Groups/GetFamilies/51?loadAttributes=expanded&%24expand=Campus&%24top=1",
+    "/Groups/GetFamilies/51?loadAttributes=expanded&%24expand=Campus%2CCampus%2FLocation%2CCampus%2FLocation%2FImage&%24top=1",
     Object {},
     Object {},
   ],
@@ -250,7 +252,7 @@ Array [
     Object {},
   ],
   Array [
-    "/Groups/GetFamilies/51?loadAttributes=expanded&%24expand=Campus&%24top=1",
+    "/Groups/GetFamilies/51?loadAttributes=expanded&%24expand=Campus%2CCampus%2FLocation%2CCampus%2FLocation%2FImage&%24top=1",
     Object {},
     Object {},
   ],

--- a/packages/apollos-data-connector-rock/src/campuses/__tests__/resolver.tests.js
+++ b/packages/apollos-data-connector-rock/src/campuses/__tests__/resolver.tests.js
@@ -169,6 +169,8 @@ describe('Campus', () => {
             campus {
               id
               name
+              latitude
+              longitude
             }
           }
         }
@@ -177,7 +179,15 @@ describe('Campus', () => {
     const rootValue = {};
 
     const getMock = jest.fn(() =>
-      Promise.resolve([{ campus: { id: 1, name: 'the best campus' } }])
+      Promise.resolve([
+        {
+          campus: {
+            id: 1,
+            name: 'the best campus',
+            location: { latitude: 1.1, longitude: 2.2 },
+          },
+        },
+      ])
     );
 
     context.dataSources.Campus.get = getMock;

--- a/packages/apollos-data-connector-rock/src/campuses/data-source.js
+++ b/packages/apollos-data-connector-rock/src/campuses/data-source.js
@@ -42,6 +42,8 @@ export default class Campus extends RockApolloDataSource {
   getForPerson = async ({ personId }) => {
     const family = await this.request(`/Groups/GetFamilies/${personId}`)
       .expand('Campus')
+      .expand('Campus/Location')
+      .expand('Campus/Location/Image')
       .first();
 
     if (family) {


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

When getting campuses for the current user, I wasn't expanding the location object so `lat` and `long` were returning null. 

This PR causes the `location` object to be expanded, so now you can get `lat` and `long` from the user's campus.

### What design trade-offs/decisions were made?

### How do I test this PR?

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [x] Read through the "Files changed" tab _very carefully_
- [x] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
