### PR TITLE
undo mounting graphql at root to fix pass generation

### DIFF
--- a/packages/apollos-church-api/src/server.js
+++ b/packages/apollos-church-api/src/server.js
@@ -43,7 +43,8 @@ const apolloServer = new ApolloServer({
 
 const app = express();
 
-apolloServer.applyMiddleware({ app });
 applyServerMiddleware({ app, dataSources, context });
+apolloServer.applyMiddleware({ app });
+apolloServer.applyMiddleware({ app, path: '/' });
 
 export default app;

--- a/packages/apollos-church-api/src/server.js
+++ b/packages/apollos-church-api/src/server.js
@@ -44,7 +44,6 @@ const apolloServer = new ApolloServer({
 const app = express();
 
 apolloServer.applyMiddleware({ app });
-apolloServer.applyMiddleware({ app, path: '/' });
 applyServerMiddleware({ app, dataSources, context });
 
 export default app;


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

a PR was added that mounts graphql at the root, which turns out broke pass generation. This PR reverses that change.

### What design trade-offs/decisions were made?

can no longer access graphql at `/`

### How do I test this PR?

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
