### PR TITLE
Fixes Live Content Timezones

### DIFF
--- a/packages/apollos-data-connector-rock/src/content-items/data-source.js
+++ b/packages/apollos-data-connector-rock/src/content-items/data-source.js
@@ -159,16 +159,11 @@ export default class ContentItem extends RockApolloDataSource {
 
   LIVE_CONTENT = () => {
     // get a date in the local timezone of the rock instance.
-    // Rock doesn't respect timezone information, hence the need to warp the date
+    // should output something like 2019-03-27T12:27:20-04:00 which means 12:27 in New York
     const date = moment()
-      .utc()
-      .add(
-        moment()
-          .tz(ROCK.TIMEZONE)
-          .utcOffset(),
-        'minutes'
-      );
-    return `((StartDateTime lt datetime'${date.toISOString()}') or (StartDateTime eq null)) and ((ExpireDateTime gt datetime'${date.toISOString()}') or (ExpireDateTime eq null)) `;
+      .tz(ROCK.TIMEZONE)
+      .format();
+    return `((StartDateTime lt datetime'${date}') or (StartDateTime eq null)) and ((ExpireDateTime gt datetime'${date}') or (ExpireDateTime eq null)) `;
   };
 
   expanded = true;


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Currently we are sending dates in this format:

`2019-03-27T12:31:11Z`

... knowing that Rock doesn't respect the "Z" so we are adding hours to that time to make up for it.

But since Rock does respect standard offset formats like this:

`2019-03-27T12:31:11-04:00`

we shouldn't need to do any fancy conversions or additions.

via John E:



### What design trade-offs/decisions were made?

None

### How do I test this PR?

Add content that:

1. Expired an hour ago
2. Doesn't go live for an hour

and make sure they don't show up

### What automated tests did you write?

None

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Closes [#490]
- [x] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._