### PR TITLE
Removes the default/automatic notifications prompt on iOS

### DIFF
--- a/packages/apolloschurchapp/src/notifications/NotificationManager.js
+++ b/packages/apolloschurchapp/src/notifications/NotificationManager.js
@@ -35,7 +35,7 @@ class NotificationsInit extends Component {
 
   componentDidMount() {
     OneSignal.init(Config.ONE_SIGNAL_KEY, {
-      kOSSettingsKeyAutoPrompt: true,
+      kOSSettingsKeyAutoPrompt: false,
     });
     OneSignal.addEventListener('received', this.onReceived);
     OneSignal.addEventListener('opened', this.onOpened);


### PR DESCRIPTION
## DESCRIPTION
Currently, the app would prompt for notification permission at launch. We now handle this in onboarding so we can disable it. 

### What does this PR do, or why is it needed?
Disables the onesignal auto prompt.

### What design trade-offs/decisions were made?
N/A

### How do I test this PR?
Delete and reinstall the app on iOS and launch. You shouldn't get the notifications prompt until you ask for it in onboarding.

### What automated tests did you write?
N/A

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Closes 💥 
- [x] No new warnings in tests, in storybook, and in-app
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
