### PR TITLE
Fixs Chip component prop warning that was noticed on onboarding

### DIFF
--- a/packages/apollos-ui-kit/src/Chip/index.js
+++ b/packages/apollos-ui-kit/src/Chip/index.js
@@ -62,8 +62,10 @@ const Chip = enhance(
       pill={pill}
       {...buttonProps}
     >
-      {title ? <TitleText withIcon={icon}>{title}</TitleText> : null}
-      {icon ? <Icon name={icon} style={iconStyles} size={iconSize} /> : null}
+      <>
+        {title ? <TitleText withIcon={icon}>{title}</TitleText> : null}
+        {icon ? <Icon name={icon} style={iconStyles} size={iconSize} /> : null}
+      </>
     </StyledButton>
   )
 );

--- a/packages/apolloschurchapp/src/ui/Onboarding/Slide/index.js
+++ b/packages/apolloschurchapp/src/ui/Onboarding/Slide/index.js
@@ -34,7 +34,8 @@ const SkipButton = styled(({ theme }) => ({
   marginLeft: theme.sizing.baseUnit * -1, // adjusts for paddingHorizontal
 }))(ButtonLink);
 
-// memo = sfc PureComponent 💥
+/* Slide uses memo = sfc PureComponent 💥 Additionally, this component when rendered in a `Slider`
+ * is automatically rendered in a `View` */
 // eslint-disable-next-line react/display-name
 const Slide = memo(
   ({

--- a/packages/apolloschurchapp/src/ui/Onboarding/slides/AboutYou/AboutYou.js
+++ b/packages/apolloschurchapp/src/ui/Onboarding/slides/AboutYou/AboutYou.js
@@ -101,7 +101,6 @@ const AboutYou = memo(
               ])}
             </StyledRadio>
           </View>
-          {/* TODO: getting some warning with this DateInput */}
           <View>
             <Label>Birthday</Label>
             <StyledDate


### PR DESCRIPTION
## DESCRIPTION
Bye bye, annoying warning we would see all the time in onboarding. This was actually caused by the `Chip` component used in the `DatePicker` component and if you used `Chip` with the `icon` prop it would render two components and throw this error.

### What does this PR do, or why is it needed?
All this does is use `<></>` fragments inside `Chip` and 💥 we're good.

### What design trade-offs/decisions were made?
N/A

### How do I test this PR?
Open onboarding and you shouldn't see any warnings anymore. Specifically one related to rendering an array but expecting a single react element.

### What automated tests did you write?
N/A

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings in tests, in storybook, and in-app 💥 
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
