### PR TITLE
Adds binary files datasource

### DIFF
--- a/packages/apollos-church-api/src/data/index.js
+++ b/packages/apollos-church-api/src/data/index.js
@@ -22,6 +22,7 @@ import {
   Template,
   AuthSms,
   Campus,
+  BinaryFiles,
 } from '@apollosproject/data-connector-rock';
 import * as Theme from './theme';
 
@@ -51,6 +52,7 @@ const data = {
   Pass,
   Template,
   Campus,
+  BinaryFiles,
 };
 
 const {

--- a/packages/apollos-data-connector-rock/src/binary-files/__tests__/__snapshots__/binary-files.tests.js.snap
+++ b/packages/apollos-data-connector-rock/src/binary-files/__tests__/__snapshots__/binary-files.tests.js.snap
@@ -1,0 +1,72 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Binary files resolver returns a url if the person object has a id 1`] = `
+Object {
+  "uri": "https://example.com/1.jpg",
+}
+`;
+
+exports[`Binary files resolver returns a url if the person object has a id 2`] = `
+Array [
+  Array [
+    "BinaryFiles/123",
+    Object {},
+    Object {},
+  ],
+]
+`;
+
+exports[`Binary files resolver returns a url if the person object has a url 1`] = `
+Object {
+  "uri": "http://alreadyhere.com/1.jpg",
+}
+`;
+
+exports[`Binary files resolver returns a url if the person object has a url 2`] = `Array []`;
+
+exports[`Binary files resolver returns null with no image 1`] = `
+Object {
+  "uri": null,
+}
+`;
+
+exports[`Binary files resolver returns null with no image 2`] = `Array []`;
+
+exports[`BinaryFiles uploads a user's profile picture 1`] = `"245"`;
+
+exports[`BinaryFiles uploads a user's profile picture 2`] = `
+Array [
+  Array [
+    "https://apollosrock.newspring.cc/api/BinaryFiles/Upload?binaryFileTypeId=5",
+    Object {
+      "body": FormData {
+        "_boundary": "--------------------------",
+        "_currentStream": null,
+        "_overheadLength": 155,
+        "_released": false,
+        "_streams": Array [
+          "----------------------------
+Content-Disposition: form-data; name=\\"file\\"; filename=\\"something.jpg\\"
+Content-Type: image/jpeg
+
+",
+          "123",
+          [Function],
+        ],
+        "_valueLength": 3,
+        "_valuesToMeasure": Array [],
+        "dataSize": 0,
+        "maxDataSize": 2097152,
+        "pauseStreams": true,
+        "readable": true,
+        "writable": false,
+      },
+      "headers": Object {
+        "Authorization-Token": "some-rock-token",
+        "content-type": "multipart/form-data; boundary=--------------------------",
+      },
+      "method": "POST",
+    },
+  ],
+]
+`;

--- a/packages/apollos-data-connector-rock/src/binary-files/__tests__/binary-files.tests.js
+++ b/packages/apollos-data-connector-rock/src/binary-files/__tests__/binary-files.tests.js
@@ -1,0 +1,92 @@
+import ApollosConfig from '@apollosproject/config';
+import { dataSource as BinaryFilesDataSource, resolver } from '../index';
+
+ApollosConfig.loadJs({
+  ROCK: {
+    API_URL: 'https://apollosrock.newspring.cc/api',
+    API_TOKEN: 'some-rock-token',
+    IMAGE_URL: 'https://apollosrock.newspring.cc/GetImage.ashx',
+  },
+});
+
+describe('BinaryFiles', () => {
+  it("uploads a user's profile picture", async () => {
+    const dataSource = new BinaryFilesDataSource();
+    dataSource.nodeFetch = jest.fn(() =>
+      Promise.resolve({ text: () => '245' })
+    );
+
+    const result = await dataSource.uploadFile(
+      { stream: '123', filename: 'something.jpg' },
+      456
+    );
+    expect(result).toMatchSnapshot();
+    const nodeFetchCalls = dataSource.nodeFetch.mock.calls;
+    // Remove randomly generated multipart boundary.
+    nodeFetchCalls[0][1].body._boundary = nodeFetchCalls[0][1].body._boundary.replace(
+      /\d+/,
+      ''
+    );
+    nodeFetchCalls[0][1].body._streams[0] = nodeFetchCalls[0][1].body._streams[0].replace(
+      /\d+/,
+      ''
+    );
+    nodeFetchCalls[0][1].headers['content-type'] = nodeFetchCalls[0][1].headers[
+      'content-type'
+    ].replace(/\d+/, '');
+    expect(nodeFetchCalls).toMatchSnapshot();
+  });
+});
+
+describe('Binary files resolver', () => {
+  it('returns a url if the person object has a url', async () => {
+    const BinaryFiles = new BinaryFilesDataSource();
+    BinaryFiles.get = jest.fn(() =>
+      Promise.resolve({ url: 'https://example.com/1.jpg' })
+    );
+    const result = await resolver.Person.photo(
+      {
+        photo: {
+          id: 123,
+          url: 'http://alreadyhere.com/1.jpg',
+        },
+      },
+      null,
+      { dataSources: { BinaryFiles } }
+    );
+    expect(result).toMatchSnapshot();
+    expect(BinaryFiles.get.mock.calls).toMatchSnapshot();
+  });
+  it('returns a url if the person object has a id', async () => {
+    const BinaryFiles = new BinaryFilesDataSource();
+    BinaryFiles.get = jest.fn(() =>
+      Promise.resolve({ url: 'https://example.com/1.jpg' })
+    );
+    const result = await resolver.Person.photo(
+      {
+        photo: {
+          id: 123,
+        },
+      },
+      null,
+      { dataSources: { BinaryFiles } }
+    );
+    expect(result).toMatchSnapshot();
+    expect(BinaryFiles.get.mock.calls).toMatchSnapshot();
+  });
+  it('returns null with no image', async () => {
+    const BinaryFiles = new BinaryFilesDataSource();
+    BinaryFiles.get = jest.fn(() =>
+      Promise.resolve({ url: 'https://example.com/1.jpg' })
+    );
+    const result = await resolver.Person.photo(
+      {
+        photo: {},
+      },
+      null,
+      { dataSources: { BinaryFiles } }
+    );
+    expect(result).toMatchSnapshot();
+    expect(BinaryFiles.get.mock.calls).toMatchSnapshot();
+  });
+});

--- a/packages/apollos-data-connector-rock/src/binary-files/data-source.js
+++ b/packages/apollos-data-connector-rock/src/binary-files/data-source.js
@@ -1,0 +1,45 @@
+import FormData from 'form-data';
+
+import RockApolloDataSource from '@apollosproject/rock-apollo-data-source';
+
+export default class BinaryFiles extends RockApolloDataSource {
+  resource = 'BinaryFiles';
+
+  getFromId(id) {
+    return this.request()
+      .find(id)
+      .get();
+  }
+
+  async uploadFile({ filename, stream, length }) {
+    const data = new FormData();
+    data.append('file', stream, {
+      filename,
+      knownLength: length,
+    });
+    const response = await this.nodeFetch(
+      `${this.baseURL}/BinaryFiles/Upload?binaryFileTypeId=5`,
+      {
+        method: 'POST',
+        body: data,
+        headers: {
+          'Authorization-Token': this.rockToken,
+          ...data.getHeaders(),
+        },
+      }
+    );
+
+    return response.text();
+  }
+
+  async findOrReturnImageUrl({ url, id }) {
+    if (url && typeof url === 'string') {
+      return url;
+    }
+    if (id != null && typeof id !== 'object') {
+      const image = await this.getFromId(id);
+      return image.url;
+    }
+    return null;
+  }
+}

--- a/packages/apollos-data-connector-rock/src/binary-files/index.js
+++ b/packages/apollos-data-connector-rock/src/binary-files/index.js
@@ -1,0 +1,4 @@
+import resolver from './resolver';
+import dataSource from './data-source';
+
+export { resolver, dataSource };

--- a/packages/apollos-data-connector-rock/src/binary-files/resolver.js
+++ b/packages/apollos-data-connector-rock/src/binary-files/resolver.js
@@ -1,0 +1,7 @@
+export default {
+  Person: {
+    photo: async ({ photo }, args, { dataSources: { BinaryFiles } }) => ({
+      uri: await BinaryFiles.findOrReturnImageUrl(photo),
+    }),
+  },
+};

--- a/packages/apollos-data-connector-rock/src/index.js
+++ b/packages/apollos-data-connector-rock/src/index.js
@@ -11,6 +11,7 @@ import * as PersonalDevice from './personal-devices';
 import * as Template from './template';
 import * as Campus from './campuses';
 import * as Utils from './utils';
+import * as BinaryFiles from './binary-files';
 
 export {
   Followings,
@@ -26,4 +27,5 @@ export {
   AuthSms,
   Campus,
   Utils,
+  BinaryFiles,
 };

--- a/packages/apollos-data-connector-rock/src/people/__tests__/__snapshots__/data-source.tests.js.snap
+++ b/packages/apollos-data-connector-rock/src/people/__tests__/__snapshots__/data-source.tests.js.snap
@@ -122,7 +122,42 @@ Object {
 }
 `;
 
-exports[`Person uploads a user's profile picture 1`] = `
+exports[`Person uploads a user's profile picture: Get media datasource mock 1`] = `
+Array [
+  Array [
+    "456",
+  ],
+]
+`;
+
+exports[`Person uploads a user's profile picture: Get updated profile mock 1`] = `Array []`;
+
+exports[`Person uploads a user's profile picture: Update profile mock 1`] = `
+Array [
+  Array [
+    Array [
+      Object {
+        "field": "PhotoId",
+        "value": "456",
+      },
+    ],
+  ],
+]
+`;
+
+exports[`Person uploads a user's profile picture: Upload datasource mock 1`] = `
+Array [
+  Array [
+    Object {
+      "filename": "img.jpg",
+      "length": 456,
+      "stream": "123",
+    },
+  ],
+]
+`;
+
+exports[`Person uploads a user's profile picture: Upload result 1`] = `
 Object {
   "firstName": "Vincent",
   "id": 51,
@@ -131,64 +166,5 @@ Object {
     "id": 123,
     "url": "http://imageurl.....",
   },
-}
-`;
-
-exports[`Person uploads a user's profile picture 2`] = `
-Array [
-  Array [
-    "https://apollosrock.newspring.cc/api/BinaryFiles/Upload?binaryFileTypeId=5",
-    Object {
-      "body": FormData {
-        "_boundary": "--------------------------",
-        "_currentStream": null,
-        "_overheadLength": 103,
-        "_released": false,
-        "_streams": Array [
-          "----------------------------
-Content-Disposition: form-data; name=\\"file\\"
-
-",
-          "123",
-          [Function],
-        ],
-        "_valueLength": 456,
-        "_valuesToMeasure": Array [],
-        "dataSize": 0,
-        "maxDataSize": 2097152,
-        "pauseStreams": true,
-        "readable": true,
-        "writable": false,
-      },
-      "headers": Object {
-        "Authorization-Token": "some-rock-token",
-        "content-type": "multipart/form-data; boundary=--------------------------",
-      },
-      "method": "POST",
-    },
-  ],
-]
-`;
-
-exports[`Person uploads a user's profile picture 3`] = `
-Object {
-  "0": Array [
-    Array [
-      Object {
-        "field": "PhotoId",
-        "value": "245",
-      },
-    ],
-  ],
-}
-`;
-
-exports[`Person uploads a user's profile picture 4`] = `
-Object {
-  "0": Array [
-    "/BinaryFiles?%24filter=Id%20eq%20245&%24top=1",
-    Object {},
-    Object {},
-  ],
 }
 `;


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

The person resolver needs to fetch an image for a person if the URI is not provided on the data returned in the root. A common issue when fetching lists of people. Requested by @IsaacHardy in #697 

While writing this feature, I took an opportunity to create a BinaryFiles dataSource, which should make it easier for NS and future teams to handle uploading/fetching photos in future repos.

### What design trade-offs/decisions were made?

### How do I test this PR?

This PR covers the file uploading code, so be sure to visit the connect tab and upload a new profile pic.

### What automated tests did you write?

100% test coverage

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Closes #697 
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
