### PR TITLE
Fixes personal devices "post" by providing required rock field

### DIFF
--- a/packages/apollos-data-connector-rock/src/personal-devices/__tests__/__snapshots__/data-source.tests.js.snap
+++ b/packages/apollos-data-connector-rock/src/personal-devices/__tests__/__snapshots__/data-source.tests.js.snap
@@ -21,6 +21,7 @@ exports[`Personal device data source must post a user's device to Rock 2`] = `
       "/PersonalDevices",
       Object {
         "DeviceRegistrationId": "somepushid",
+        "IsActive": 1,
         "NotificationsEnabled": 1,
         "PersonAliasId": 123,
         "PersonalDeviceTypeValueId": 671,

--- a/packages/apollos-data-connector-rock/src/personal-devices/data-source.js
+++ b/packages/apollos-data-connector-rock/src/personal-devices/data-source.js
@@ -22,6 +22,7 @@ export default class PersonalDevices extends RockApolloDataSource {
       DeviceRegistrationId: pushId,
       PersonalDeviceTypeValueId: 671, // `mobile` device type
       NotificationsEnabled: 1,
+      IsActive: 1,
     });
 
     return currentUser;


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Rich ran into this issue when building out push support in Rock. Apparently newer versions of Rock have this as a required field. Older versions of Rock will accept this new "IsActive" field and safely ignore it. 

### What design trade-offs/decisions were made?

### How do I test this PR?

1. Open the app with a new device. (could be a new sim) 
2. Go through onboarding
3. Accept push notifications
4. Make sure you have a personal device listed in rock (and you don't see any failures in the server log)

### What automated tests did you write?

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Closes 705
- [x] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
