### PR TITLE
Updates bible.api usage to match current practices

### DIFF
--- a/packages/apollos-apollo-server-env-mock/src/apollo-datasource-mocks/bible.js
+++ b/packages/apollos-apollo-server-env-mock/src/apollo-datasource-mocks/bible.js
@@ -1,47 +1,43 @@
 export default () => [
   {
-    data: {
-      passages: [
-        {
-          id: 'SNG.1.1',
-          orgId: 'SNG.1.1',
-          bibleId: '9879dbb7cfe39e4d-01',
-          bookId: 'SNG',
-          chapterIds: ['SNG.1'],
-          reference: 'Song of Solomon 1:1',
-          content:
-            '<p class="p"><span data-number="1" class="v">1</span>The Song of songs, which is Solomon’s.</p>',
-          copyright: 'PUBLIC DOMAIN',
-        },
-      ],
-    },
+    data: [
+      {
+        id: 'SNG.1.1',
+        orgId: 'SNG.1.1',
+        bibleId: '9879dbb7cfe39e4d-01',
+        bookId: 'SNG',
+        chapterIds: ['SNG.1'],
+        reference: 'Song of Solomon 1:1',
+        content:
+          '<p class="p"><span data-number="1" class="v">1</span>The Song of songs, which is Solomon’s.</p>',
+        copyright: 'PUBLIC DOMAIN',
+      },
+    ],
   },
   {
-    data: {
-      passages: [
-        {
-          id: '1PE.1.1',
-          orgId: '1PE.1.1',
-          bibleId: '9879dbb7cfe39e4d-01',
-          bookId: '1PE',
-          chapterIds: ['1PE.1'],
-          reference: '1 Peter 1:1',
-          content:
-            '<p class="p"><span data-number="1" class="v">1</span>Peter, an apostle of Jesus Christ, to the chosen ones who are living as foreigners in the Dispersion in Pontus, Galatia, Cappadocia, Asia, and Bithynia, </p>',
-          copyright: 'PUBLIC DOMAIN',
-        },
-        {
-          id: 'JHN.3.16',
-          orgId: 'JHN.3.16',
-          bibleId: '9879dbb7cfe39e4d-01',
-          bookId: 'JHN',
-          chapterIds: ['JHN.3'],
-          reference: 'John 3:16',
-          content:
-            '<p class="p"><span data-number="16" class="v">16</span><span class="wj">For God so loved the world, that he gave his one and only Son, that whoever believes in him should not perish, but have eternal life. </span></p>',
-          copyright: 'PUBLIC DOMAIN',
-        },
-      ],
-    },
+    data: [
+      {
+        id: '1PE.1.1',
+        orgId: '1PE.1.1',
+        bibleId: '9879dbb7cfe39e4d-01',
+        bookId: '1PE',
+        chapterIds: ['1PE.1'],
+        reference: '1 Peter 1:1',
+        content:
+          '<p class="p"><span data-number="1" class="v">1</span>Peter, an apostle of Jesus Christ, to the chosen ones who are living as foreigners in the Dispersion in Pontus, Galatia, Cappadocia, Asia, and Bithynia, </p>',
+        copyright: 'PUBLIC DOMAIN',
+      },
+      {
+        id: 'JHN.3.16',
+        orgId: 'JHN.3.16',
+        bibleId: '9879dbb7cfe39e4d-01',
+        bookId: 'JHN',
+        chapterIds: ['JHN.3'],
+        reference: 'John 3:16',
+        content:
+          '<p class="p"><span data-number="16" class="v">16</span><span class="wj">For God so loved the world, that he gave his one and only Son, that whoever believes in him should not perish, but have eternal life. </span></p>',
+        copyright: 'PUBLIC DOMAIN',
+      },
+    ],
   },
 ];

--- a/packages/apollos-data-connector-bible/src/data-source.js
+++ b/packages/apollos-data-connector-bible/src/data-source.js
@@ -18,8 +18,8 @@ export default class Scripture extends RESTDataSource {
   async getScripture(query) {
     const bibleId = BIBLE_API.BIBLE_ID;
     const scriptures = await this.get(`${bibleId}/search?query=${query}`);
-    if (get(scriptures, 'data.passages[0]')) {
-      return scriptures.data.passages[0];
+    if (get(scriptures, 'data[0]')) {
+      return scriptures.data[0];
     }
     return null;
   }
@@ -27,6 +27,6 @@ export default class Scripture extends RESTDataSource {
   async getScriptures(query) {
     const bibleId = BIBLE_API.BIBLE_ID;
     const scriptures = await this.get(`${bibleId}/search?query=${query}`);
-    return scriptures.data.passages;
+    return scriptures.data;
   }
 }


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Fixes our Bible.API usage to match current standards. I'm not sure why this broke, but it broke recently. I can't think of a way we could have anticipated this change, nor can I find reference to this change on bible.api's site 🤷‍♂ 

### What design trade-offs/decisions were made?

### How do I test this PR?

1. `yarn install`
2. Run the following query in Apollo
```
{
  scriptures(query: "1 John 3:16, Romans 6:6"){
    id   
    html
  }
}

```

### What automated tests did you write?

Used existing automated tests.

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
