### PR TITLE
Preloads Recent Likes

### DIFF
--- a/packages/apolloschurchapp/src/ui/LikeButton/index.js
+++ b/packages/apolloschurchapp/src/ui/LikeButton/index.js
@@ -7,6 +7,7 @@ import { Query, Mutation } from 'react-apollo';
 import Like from 'apolloschurchapp/src/ui/Like';
 import { AnalyticsConsumer } from '@apollosproject/ui-analytics';
 
+import getLikedContent from '../../tabs/connect/getLikedContent';
 import updateLikeEntity from './updateLikeEntity';
 import getLikedContentItem from './getLikedContentItem';
 import updateLikedContent from './updateLikedContent';
@@ -15,7 +16,14 @@ const GetLikeData = ({ itemId, children }) => (
   <Query query={getLikedContentItem} variables={{ itemId }}>
     {({ data: { node = {} } = {}, loading }) => {
       const isLiked = loading ? false : get(node, 'isLiked') || false;
-      return children({ isLiked, item: node });
+      return (
+        // This preemptively loads getLikedContent into cache.
+        // The only reason this is necessary is because we are reading this
+        // particular query from cache in the updateLikedContent mutation.
+        <Query query={getLikedContent} variables={{ first: 3 }}>
+          {() => children({ isLiked, item: node })}
+        </Query>
+      );
     }}
   </Query>
 );


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

The runs the `getLikedContent` query preemptively when we like something. This is simply to load the query into cache since we read it from the cache later in the `updateLikedContent` mutation. Since it can't currently find the query in cache to read from, it just try/catches out the error so the cache was never actually updated the first time.

### What design trade-offs/decisions were made?

Don't love this but I don't know of a way around it. If we could avoid using `cache.readQuery` in the update mutation, it wouldn't error out in the first place. Maybe we could pass in what we need instead?

### How do I test this PR?

Clear all your liked content, refresh the app, the like something for the first time and make sure it shows up in the recent liked feed in the connect tab.

### What automated tests did you write?

None.

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Closes [#672]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._