### PR TITLE
Fixes Liked Content Feed not populating on first like. 

### DIFF
--- a/packages/apollos-data-connector-rock/src/content-items/__tests__/__snapshots__/data-source.tests.js.snap
+++ b/packages/apollos-data-connector-rock/src/content-items/__tests__/__snapshots__/data-source.tests.js.snap
@@ -120,6 +120,27 @@ Object {
 }
 `;
 
+exports[`ContentItemsModel gets by ids 1`] = `
+Array [
+  Array [
+    "ContentChannelItems?loadAttributes=expanded&%24filter=%28%28Id%20eq%201%29%20or%20%28Id%20eq%202%29%29%20and%20%28%28%28StartDateTime%20lt%20datetime%272017-11-25T07%3A34%3A56%27%29%20or%20%28StartDateTime%20eq%20null%29%29%20and%20%28%28ExpireDateTime%20gt%20datetime%272017-11-25T07%3A34%3A56%27%29%20or%20%28ExpireDateTime%20eq%20null%29%29%20%29",
+    Object {},
+    Object {},
+  ],
+]
+`;
+
+exports[`ContentItemsModel gets by ids 2`] = `
+Array [
+  Object {
+    "id": 1,
+  },
+  Object {
+    "id": 2,
+  },
+]
+`;
+
 exports[`ContentItemsModel returns null when there are no child content items 1`] = `
 Array [
   Array [

--- a/packages/apollos-data-connector-rock/src/content-items/__tests__/data-source.tests.js
+++ b/packages/apollos-data-connector-rock/src/content-items/__tests__/data-source.tests.js
@@ -50,6 +50,22 @@ describe('ContentItemsModel', () => {
     expect(dataSource.get.mock.calls).toMatchSnapshot();
   });
 
+  it('gets by ids', () => {
+    const dataSource = new ContentItemsDataSource();
+    dataSource.get = buildGetMock([{ Id: 1 }, { Id: 2 }], dataSource);
+    const result = dataSource.getFromIds([1, 2]).get();
+    expect(result).resolves.toMatchSnapshot();
+    expect(dataSource.get.mock.calls).toMatchSnapshot();
+  });
+
+  it('returns an empty array when calling getByIds with no ids', () => {
+    const dataSource = new ContentItemsDataSource();
+    dataSource.get = jest.fn();
+    const result = dataSource.getFromIds([]).get();
+    expect(result).resolves.toEqual([]);
+    expect(dataSource.get.mock.calls.length).toEqual(0);
+  });
+
   it('gets a cursor finding child content items of a provided parent', async () => {
     const dataSource = new ContentItemsDataSource();
     dataSource.get = buildGetMock(

--- a/packages/apollos-data-connector-rock/src/content-items/data-source.js
+++ b/packages/apollos-data-connector-rock/src/content-items/data-source.js
@@ -280,10 +280,12 @@ export default class ContentItem extends RockApolloDataSource {
       .andFilter(this.LIVE_CONTENT())
       .orderBy('StartDateTime', 'desc');
 
-  getFromIds = (ids) =>
-    this.request()
+  getFromIds = (ids = []) => {
+    if (ids.length === 0) return this.request().empty();
+    return this.request()
       .filterOneOf(ids.map((id) => `Id eq ${id}`))
       .andFilter(this.LIVE_CONTENT());
+  };
 
   getFromId = (id) =>
     this.request()

--- a/packages/apollos-rock-apollo-data-source/src/__tests__/request-builder.tests.js
+++ b/packages/apollos-rock-apollo-data-source/src/__tests__/request-builder.tests.js
@@ -116,6 +116,10 @@ describe('RequestBuilder', () => {
     expect(request.orderBy('MyField', 'desc').get()).resolves.toMatchSnapshot();
   });
 
+  it('returns an empty array', () => {
+    expect(request.empty().get()).resolves.toEqual([]);
+  });
+
   it('transforms result shapes', () => {
     get = jest.fn(() => new Promise((resolve) => resolve({ a: 'yo' })));
     connector = { get };

--- a/packages/apollos-rock-apollo-data-source/src/request-builder.js
+++ b/packages/apollos-rock-apollo-data-source/src/request-builder.js
@@ -43,6 +43,12 @@ export default class RockRequestBuilder {
       });
 
   /**
+   * Ends the request chain, ensuring that the caller of *get* will recieve an empty array.
+   * Used in situations where we want to bypass Rock and return nothing.
+   */
+  empty = () => ({ get: () => Promise.resolve([]) });
+
+  /**
    * Sends a GET request to the server, resolves with the first promise
    * @returns promise
    */


### PR DESCRIPTION
## DESCRIPTION


### What does this PR do, or why is it needed?
**Calling `getById` with no ids should always return an empty array**

Because the user hadn't liked any content, the resolver assumed that the user had liked ALL the content. This resulted in an error on the `getLikedContent` query when the user hadn't liked any content, due to an assumption being made about the length of the `following` array and the `contentItem` array in the resolver 

### What design trade-offs/decisions were made?

n/a 

### How do I test this PR?
1. Unlike all content.
2. Refresh the app.
3. Visit the Connect tab, make sure you don't see any liked content.
4. Like some content.
5. Visit the Connect content tab, make sure you see the content you liked.

### What automated tests did you write?

Unit tests over new dataSource logic. 

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Closes #672
- [x] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
