### PR TITLE
Fixes Avatar Margin

### DIFF
--- a/packages/apolloschurchapp/src/tabs/connect/UserAvatarHeader/__snapshots__/UserAvatarHeader.test.js.snap
+++ b/packages/apolloschurchapp/src/tabs/connect/UserAvatarHeader/__snapshots__/UserAvatarHeader.test.js.snap
@@ -83,7 +83,15 @@ exports[`user avatar header renders placeholder when loading 1`] = `
                 }
               }
             >
-              <View>
+              <View
+                style={
+                  Object {
+                    "marginBottom": 12,
+                    "marginRight": 0,
+                    "marginTop": 8,
+                  }
+                }
+              >
                 <View
                   style={
                     Object {
@@ -503,7 +511,15 @@ exports[`user avatar header renders user avatar header if logged in 1`] = `
                 }
               }
             >
-              <View>
+              <View
+                style={
+                  Object {
+                    "marginBottom": 12,
+                    "marginRight": 0,
+                    "marginTop": 8,
+                  }
+                }
+              >
                 <View
                   style={
                     Object {

--- a/packages/apolloschurchapp/src/tabs/connect/UserAvatarHeader/__snapshots__/UserAvatarHeaderConnected.tests.js.snap
+++ b/packages/apolloschurchapp/src/tabs/connect/UserAvatarHeader/__snapshots__/UserAvatarHeaderConnected.tests.js.snap
@@ -83,7 +83,15 @@ exports[`user avatar header connect renders user avatar header if logged in 1`] 
                 }
               }
             >
-              <View>
+              <View
+                style={
+                  Object {
+                    "marginBottom": 12,
+                    "marginRight": 0,
+                    "marginTop": 8,
+                  }
+                }
+              >
                 <View
                   style={
                     Object {
@@ -129,8 +137,6 @@ exports[`user avatar header connect renders user avatar header if logged in 1`] 
                           "bottom": 0,
                           "height": "100%",
                           "left": 0,
-                          "marginBottom": 8,
-                          "marginRight": 0,
                           "opacity": 0,
                           "position": "absolute",
                           "right": 0,

--- a/packages/apolloschurchapp/src/ui/UserAvatarView/AvatarForm.js
+++ b/packages/apolloschurchapp/src/ui/UserAvatarView/AvatarForm.js
@@ -28,10 +28,11 @@ GetPhotoData.propTypes = {
   children: PropTypes.func.isRequired,
 };
 
-const StyledAvatar = styled(({ theme }) => ({
+const StyledView = styled(({ theme }) => ({
   marginRight: 0,
-  marginBottom: theme.sizing.baseUnit / 2,
-}))(Avatar);
+  marginBottom: theme.sizing.baseUnit * 0.75,
+  marginTop: theme.sizing.baseUnit * 0.5,
+}))(View);
 
 const RoundTouchable = withTheme(({ theme, size }) => ({
   borderRadius: get(theme.sizing.avatar, size, theme.sizing.avatar.small),
@@ -78,13 +79,13 @@ export default class AvatarForm extends PureComponent {
             >
               <GetPhotoData>
                 {({ photo }) => (
-                  <View>
-                    <StyledAvatar
+                  <StyledView>
+                    <Avatar
                       source={photo}
                       size="medium"
                       isLoading={isUploadingFile}
                     />
-                  </View>
+                  </StyledView>
                 )}
               </GetPhotoData>
             </RoundTouchable>


### PR DESCRIPTION
## DESCRIPTION

![phones](https://user-images.githubusercontent.com/2659478/58651163-8a878a80-82de-11e9-8ebc-1c084538df00.png)


### What does this PR do, or why is it needed?

Adds margin back to the user settings avatar that we lost when we refactored the `Avatar`.

### What design trade-offs/decisions were made?

None.

### How do I test this PR?

1. Boot up and look at the connect tab
2. `yarn test`

### What automated tests did you write?

None.

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Closes [#718]
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._