### PR TITLE
Exports ContentItemInterfaceFields and document usage

### DIFF
--- a/packages/apollos-data-connector-rock/README.md
+++ b/packages/apollos-data-connector-rock/README.md
@@ -209,6 +209,20 @@ Adding a new ContentItemType is a common operation, and we have some configurati
 
 If determining the `ContentItem` type is more complex than something like` ContentChannelTypeId`, you'll need to override the `__resolveType` function on the `ContentItem` resolver.
 
+To include all the existing fields on the `ContentItem` interface, you can use the following variable. This method is preferred to copy and pasting them.
+
+```
+import { ContentItemInterfaceFields } from '@apollosproject/data-schema';
+
+const newItemSchema = gql`
+type MyNewItem implements ContentItem {
+${ContentItemInterfaceFields}
+
+  someNewField: String
+}
+`
+```
+
 ### F.A.Q
 
 #### Q: How do I figure out what methods are on X data source?

--- a/packages/apollos-data-connector-rock/src/content-items/resolver.js
+++ b/packages/apollos-data-connector-rock/src/content-items/resolver.js
@@ -87,9 +87,23 @@ const resolver = {
   },
   ContentSeriesContentItem: {
     ...defaultContentItemResolvers,
+    scriptures: ({ attributeValues }, args, { dataSources }) => {
+      const reference = get(attributeValues, 'scriptures.value');
+      if (reference && reference != null) {
+        return dataSources.Scripture.getScriptures(reference);
+      }
+      return null;
+    },
   },
   MediaContentItem: {
     ...defaultContentItemResolvers,
+    scriptures: ({ attributeValues }, args, { dataSources }) => {
+      const reference = get(attributeValues, 'scriptures.value');
+      if (reference && reference != null) {
+        return dataSources.Scripture.getScriptures(reference);
+      }
+      return null;
+    },
   },
   ContentItem: {
     ...defaultContentItemResolvers,

--- a/packages/apollos-data-schema/src/index.js
+++ b/packages/apollos-data-schema/src/index.js
@@ -1,6 +1,28 @@
 import gql from 'graphql-tag';
 import { extendForEachContentItemType } from './utils';
 
+export const ContentItemInterfaceFields = `
+    id: ID!
+    title: String
+    coverImage: ImageMedia
+    images: [ImageMedia]
+    videos: [VideoMedia]
+    audios: [AudioMedia]
+    htmlContent: String
+    summary: String
+    childContentItemsConnection(
+      first: Int
+      after: String
+    ): ContentItemsConnection
+    siblingContentItemsConnection(
+      first: Int
+      after: String
+    ): ContentItemsConnection
+    parentChannel: ContentChannel
+
+    theme: Theme
+`;
+
 export const testSchema = gql`
   scalar Upload
 `;
@@ -218,114 +240,28 @@ export const analyticsSchema = gql`
 
 export const contentItemSchema = gql`
   interface ContentItem {
-    id: ID!
-    title: String
-    coverImage: ImageMedia
-    images: [ImageMedia]
-    videos: [VideoMedia]
-    audios: [AudioMedia]
-    htmlContent: String
-    summary: String
-    childContentItemsConnection(
-      first: Int
-      after: String
-    ): ContentItemsConnection
-    siblingContentItemsConnection(
-      first: Int
-      after: String
-    ): ContentItemsConnection
-    parentChannel: ContentChannel
-
-    theme: Theme
+${ContentItemInterfaceFields}
   }
 
   type UniversalContentItem implements ContentItem & Node {
-    id: ID!
-    title: String
-    coverImage: ImageMedia
-    images: [ImageMedia]
-    videos: [VideoMedia]
-    audios: [AudioMedia]
-    htmlContent: String
-    summary: String
-    childContentItemsConnection(
-      first: Int
-      after: String
-    ): ContentItemsConnection
-    siblingContentItemsConnection(
-      first: Int
-      after: String
-    ): ContentItemsConnection
-    parentChannel: ContentChannel
-    theme: Theme
+${ContentItemInterfaceFields}
   }
 
   type DevotionalContentItem implements ContentItem & Node {
-    id: ID!
-    title: String
-    coverImage: ImageMedia
-    images: [ImageMedia]
-    videos: [VideoMedia]
-    audios: [AudioMedia]
-    htmlContent: String
-    summary: String
-    childContentItemsConnection(
-      first: Int
-      after: String
-    ): ContentItemsConnection
-    siblingContentItemsConnection(
-      first: Int
-      after: String
-    ): ContentItemsConnection
-    parentChannel: ContentChannel
+${ContentItemInterfaceFields}
 
-    theme: Theme
     scriptures: [Scripture]
   }
 
   type MediaContentItem implements ContentItem & Node {
-    id: ID!
-    title: String
-    coverImage: ImageMedia
-    images: [ImageMedia]
-    videos: [VideoMedia]
-    audios: [AudioMedia]
-    htmlContent: String
-    summary: String
-    childContentItemsConnection(
-      first: Int
-      after: String
-    ): ContentItemsConnection
-    siblingContentItemsConnection(
-      first: Int
-      after: String
-    ): ContentItemsConnection
-    parentChannel: ContentChannel
+${ContentItemInterfaceFields}
 
-    theme: Theme
     scriptures: [Scripture]
   }
 
   type ContentSeriesContentItem implements ContentItem & Node {
-    id: ID!
-    title: String
-    coverImage: ImageMedia
-    images: [ImageMedia]
-    videos: [VideoMedia]
-    audios: [AudioMedia]
-    htmlContent: String
-    summary: String
-    childContentItemsConnection(
-      first: Int
-      after: String
-    ): ContentItemsConnection
-    siblingContentItemsConnection(
-      first: Int
-      after: String
-    ): ContentItemsConnection
-    parentChannel: ContentChannel
+${ContentItemInterfaceFields}
 
-    theme: Theme
     scriptures: [Scripture]
   }
 


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

As a developer, it's obnoxious to need to include the ContentItem interface fields every time you extend the interface. If we export those fields as a variable, we can give a mechanism by which developers can include all the fields on the interface without needing to copy/paste them. 

This will also make upgrading to new versions of the `ContentItem` interface easier. 

### What design trade-offs/decisions were made?

`MediaContentItem` and `SeriesContentItem` support Scripture, but don't actually fetch scripture. I fixed that in this PR. 

### How do I test this PR?

1. Download this PR.
2. Run this PR
 - Your server will crash if the new schema is invalid. 

### What automated tests did you write?

n/a

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Closes #755
- [x] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
