### PR TITLE
Adds Component prop to ConnectedComponents in Onboarding

### DIFF
--- a/packages/apollos-ui-onboarding/src/slides/AboutYou/AboutYouConnected.js
+++ b/packages/apollos-ui-onboarding/src/slides/AboutYou/AboutYouConnected.js
@@ -94,7 +94,7 @@ const AboutYouConnected = memo(
 );
 
 AboutYouConnected.propTypes = {
-  Component: PropTypes.node,
+  Component: PropTypes.node, // Custom component to be rendered. Defaults to AboutYou
   onPressPrimary: PropTypes.func,
   onPressSecondary: PropTypes.func,
 };

--- a/packages/apollos-ui-onboarding/src/slides/AboutYou/AboutYouConnected.js
+++ b/packages/apollos-ui-onboarding/src/slides/AboutYou/AboutYouConnected.js
@@ -94,7 +94,12 @@ const AboutYouConnected = memo(
 );
 
 AboutYouConnected.propTypes = {
-  Component: PropTypes.node, // Custom component to be rendered. Defaults to AboutYou
+  // Custom component to be rendered. Defaults to AboutYou
+  Component: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.func,
+    PropTypes.object,
+  ]),
   onPressPrimary: PropTypes.func,
   onPressSecondary: PropTypes.func,
 };

--- a/packages/apollos-ui-onboarding/src/slides/AboutYou/AboutYouConnected.js
+++ b/packages/apollos-ui-onboarding/src/slides/AboutYou/AboutYouConnected.js
@@ -10,7 +10,7 @@ import AboutYou from './AboutYou';
 import updateUserDetails from './updateUserDetails';
 
 const AboutYouConnected = memo(
-  ({ onPressPrimary, onPressSecondary, ...props }) => (
+  ({ Component, onPressPrimary, onPressSecondary, ...props }) => (
     <Query query={getUserGenderAndBirthDate}>
       {({ data: { currentUser = { profile: {} } } = {}, loading = false }) => {
         const { gender, birthDate } = currentUser.profile;
@@ -66,7 +66,7 @@ const AboutYouConnected = memo(
                   errors,
                   setFieldValue,
                 }) => (
-                  <AboutYou
+                  <Component
                     onPressPrimary={isValid ? submitForm : null} // if form `isValid` show the primary nav button (next)
                     onPressSecondary={
                       // if form `!isValid` show the secondary nav button (skip)
@@ -94,8 +94,13 @@ const AboutYouConnected = memo(
 );
 
 AboutYouConnected.propTypes = {
+  Component: PropTypes.node,
   onPressPrimary: PropTypes.func,
   onPressSecondary: PropTypes.func,
+};
+
+AboutYouConnected.defaultProps = {
+  Component: AboutYou,
 };
 
 AboutYouConnected.displayName = 'AboutYouConnected';

--- a/packages/apollos-ui-onboarding/src/slides/AboutYou/AboutYouConnected.tests.js
+++ b/packages/apollos-ui-onboarding/src/slides/AboutYou/AboutYouConnected.tests.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { Text } from 'react-native';
 
 import { renderWithApolloData, Providers } from '../../testUtils';
 import getUserGenderAndBirthDate from './getUserGenderAndBirthDate';
@@ -40,6 +41,40 @@ describe('AboutYouConnected component', () => {
     const tree = await renderWithApolloData(
       <Providers mocks={[mock]}>
         <AboutYouConnected setFieldValue={jest.fn()} />
+      </Providers>
+    );
+    expect(tree).toMatchSnapshot();
+  });
+  it('should render a custom Component', async () => {
+    const mock = {
+      request: {
+        query: getUserGenderAndBirthDate,
+      },
+      result: {
+        data: {
+          currentUser: {
+            __typename: 'AuthenticatedUser',
+            id: 'AuthenticatedUser:123',
+            profile: {
+              __typename: 'Person',
+              id: 'Person:123',
+              gender: 'Male',
+              birthDate: '1980-02-10T00:00:00',
+            },
+          },
+        },
+      },
+    };
+
+    const CustomComponent = ({ gender }) => <Text>{gender}</Text>; // eslint-disable-line react/prop-types
+
+    const tree = await renderWithApolloData(
+      <Providers mocks={[mock]}>
+        <AboutYouConnected
+          Component={CustomComponent}
+          onPressPrimary={jest.fn()}
+          defaultDate={'2019-02-14'}
+        />
       </Providers>
     );
     expect(tree).toMatchSnapshot();

--- a/packages/apollos-ui-onboarding/src/slides/AboutYou/__snapshots__/AboutYouConnected.tests.js.snap
+++ b/packages/apollos-ui-onboarding/src/slides/AboutYou/__snapshots__/AboutYouConnected.tests.js.snap
@@ -1321,3 +1321,43 @@ exports[`AboutYouConnected component renders in a default state 1`] = `
   </View>
 </RCTSafeAreaView>
 `;
+
+exports[`AboutYouConnected component should render a custom Component 1`] = `
+<RCTSafeAreaView
+  emulateUnlessSupported={true}
+  onLayout={[Function]}
+  style={
+    Object {
+      "bottom": 0,
+      "left": 0,
+      "position": "absolute",
+      "right": 0,
+      "top": 0,
+    }
+  }
+>
+  <View
+    onLayout={[Function]}
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  >
+    <Text>
+      Male
+    </Text>
+  </View>
+</RCTSafeAreaView>
+`;

--- a/packages/apollos-ui-onboarding/src/slides/AskName/AskNameConnected.js
+++ b/packages/apollos-ui-onboarding/src/slides/AskName/AskNameConnected.js
@@ -97,7 +97,12 @@ const AskNameConnected = memo(
 );
 
 AskNameConnected.propTypes = {
-  Component: PropTypes.node, // Custom component to be rendered. Defaults to AskName
+  // Custom component to be rendered. Defaults to AskName
+  Component: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.func,
+    PropTypes.object,
+  ]),
   onPressPrimary: PropTypes.func,
   onPressSecondary: PropTypes.func,
 };
@@ -105,5 +110,7 @@ AskNameConnected.propTypes = {
 AskNameConnected.defaultProps = {
   Component: AskName,
 };
+
+AskNameConnected.displayName = 'AskNameConnected';
 
 export default AskNameConnected;

--- a/packages/apollos-ui-onboarding/src/slides/AskName/AskNameConnected.js
+++ b/packages/apollos-ui-onboarding/src/slides/AskName/AskNameConnected.js
@@ -11,7 +11,7 @@ import updateUserName from './updateUserName';
 
 // eslint-disable-next-line react/display-name
 const AskNameConnected = memo(
-  ({ onPressPrimary, onPressSecondary, ...props }) => (
+  ({ Component, onPressPrimary, onPressSecondary, ...props }) => (
     <Query query={getUserFirstAndLastName}>
       {({ loading, data: { currentUser = { profile: {} } } = {} }) => {
         const { firstName, lastName } = currentUser.profile;
@@ -69,7 +69,7 @@ const AskNameConnected = memo(
                   errors,
                   setFieldValue,
                 }) => (
-                  <AskName
+                  <Component
                     onPressPrimary={loading || isValid ? submitForm : null} // if form `isValid` show the primary nav button (next)
                     onPressSecondary={
                       // if form `!isValid` show the secondary nav button (skip)
@@ -97,8 +97,13 @@ const AskNameConnected = memo(
 );
 
 AskNameConnected.propTypes = {
+  Component: PropTypes.node, // Custom component to be rendered. Defaults to AskName
   onPressPrimary: PropTypes.func,
   onPressSecondary: PropTypes.func,
+};
+
+AskNameConnected.defaultProps = {
+  Component: AskName,
 };
 
 export default AskNameConnected;

--- a/packages/apollos-ui-onboarding/src/slides/AskName/AskNameConnected.tests.js
+++ b/packages/apollos-ui-onboarding/src/slides/AskName/AskNameConnected.tests.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { Text } from 'react-native';
 
 import { Providers, renderWithApolloData } from '../../testUtils';
 
@@ -38,6 +39,44 @@ describe('The AskNameConnected component', () => {
     const tree = await renderWithApolloData(
       <Providers mocks={[mock]}>
         <AskNameConnected onPressPrimary={jest.fn()} />
+      </Providers>
+    );
+    expect(tree).toMatchSnapshot();
+  });
+  it('should render a custom Component', async () => {
+    const mock = {
+      request: {
+        query: getUserFirstAndLastName,
+      },
+      result: {
+        data: {
+          currentUser: {
+            __typename: 'AuthenticatedUser',
+            id: 'AuthenticatedUser:123',
+            profile: {
+              __typename: 'Person',
+              id: 'Person:123',
+              firstName: 'Isaac',
+              lastName: 'Hardy',
+            },
+          },
+        },
+      },
+    };
+
+    // eslint-disable-next-line react/prop-types
+    const CustomComponent = ({ firstName, lastName }) => (
+      <Text>
+        {`${firstName} ${lastName} thinks Skyline chili is the best.`}
+      </Text>
+    );
+
+    const tree = await renderWithApolloData(
+      <Providers mocks={[mock]}>
+        <AskNameConnected
+          Component={CustomComponent}
+          onPressPrimary={jest.fn()}
+        />
       </Providers>
     );
     expect(tree).toMatchSnapshot();

--- a/packages/apollos-ui-onboarding/src/slides/AskName/__snapshots__/AskNameConnected.tests.js.snap
+++ b/packages/apollos-ui-onboarding/src/slides/AskName/__snapshots__/AskNameConnected.tests.js.snap
@@ -2026,3 +2026,43 @@ exports[`The AskNameConnected component renders loading state when fetching data
   </View>
 </RCTSafeAreaView>
 `;
+
+exports[`The AskNameConnected component should render a custom Component 1`] = `
+<RCTSafeAreaView
+  emulateUnlessSupported={true}
+  onLayout={[Function]}
+  style={
+    Object {
+      "bottom": 0,
+      "left": 0,
+      "position": "absolute",
+      "right": 0,
+      "top": 0,
+    }
+  }
+>
+  <View
+    onLayout={[Function]}
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  >
+    <Text>
+      Isaac Hardy thinks Skyline chili is the best.
+    </Text>
+  </View>
+</RCTSafeAreaView>
+`;

--- a/packages/apollos-ui-onboarding/src/slides/AskNotifications/AskNotificationsConnected.js
+++ b/packages/apollos-ui-onboarding/src/slides/AskNotifications/AskNotificationsConnected.js
@@ -49,4 +49,6 @@ AskNotificationsConnected.defaultProps = {
   Component: AskNotifications,
 };
 
+AskNotificationsConnected.displayName = 'AskNotificationsConnected';
+
 export default AskNotificationsConnected;

--- a/packages/apollos-ui-onboarding/src/slides/AskNotifications/AskNotificationsConnected.js
+++ b/packages/apollos-ui-onboarding/src/slides/AskNotifications/AskNotificationsConnected.js
@@ -39,7 +39,7 @@ const AskNotificationsConnected = memo(
 );
 
 AskNotificationsConnected.propTypes = {
-  Component: PropTypes.node, // Custom component to be rendered. Defaults to AskName
+  Component: PropTypes.node, // Custom component to be rendered. Defaults to AskNotifications
   onPressPrimary: PropTypes.func,
   onPressSecondary: PropTypes.func,
   onRequestPushPermissions: PropTypes.func.isRequired,

--- a/packages/apollos-ui-onboarding/src/slides/AskNotifications/AskNotificationsConnected.js
+++ b/packages/apollos-ui-onboarding/src/slides/AskNotifications/AskNotificationsConnected.js
@@ -8,6 +8,7 @@ import AskNotifications from './AskNotifications';
 // eslint-disable-next-line react/display-name
 const AskNotificationsConnected = memo(
   ({
+    Component,
     onPressPrimary,
     onPressSecondary,
     onRequestPushPermissions,
@@ -15,7 +16,7 @@ const AskNotificationsConnected = memo(
   }) => (
     <Query query={getNotificationsEnabled}>
       {({ data: { notificationsEnabled = false } = {} }) => (
-        <AskNotifications
+        <Component
           onPressButton={() => onRequestPushPermissions()}
           buttonDisabled={notificationsEnabled}
           buttonText={
@@ -38,9 +39,14 @@ const AskNotificationsConnected = memo(
 );
 
 AskNotificationsConnected.propTypes = {
+  Component: PropTypes.node, // Custom component to be rendered. Defaults to AskName
   onPressPrimary: PropTypes.func,
   onPressSecondary: PropTypes.func,
   onRequestPushPermissions: PropTypes.func.isRequired,
+};
+
+AskNotificationsConnected.defaultProps = {
+  Component: AskNotifications,
 };
 
 export default AskNotificationsConnected;

--- a/packages/apollos-ui-onboarding/src/slides/AskNotifications/AskNotificationsConnected.tests.js
+++ b/packages/apollos-ui-onboarding/src/slides/AskNotifications/AskNotificationsConnected.tests.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { Text } from 'react-native';
+
 import { renderWithApolloData, Providers } from '../../testUtils';
 import getNotificationsEnabled from './getNotificationsEnabled';
 
@@ -47,7 +49,35 @@ describe('The Onboarding AskNotificationsConnected component', () => {
     const tree = await renderWithApolloData(component);
     expect(tree).toMatchSnapshot();
   });
+  it('should render a custom Component', async () => {
+    const mocks = [
+      {
+        request: {
+          query: getNotificationsEnabled,
+        },
+        result: {
+          data: { notificationsEnabled: true },
+        },
+      },
+    ];
 
+    const CustomComponent = (
+      { buttonDisabled } // eslint-disable-line react/prop-types
+    ) => (
+      // `notificationsEnabled` is passed to the `buttonDisabled` prop thus it is equal to `true` from the mock query above.
+      <Text>{`Skyline is better than Goldstar === ${buttonDisabled}`}</Text>
+    );
+
+    const tree = await renderWithApolloData(
+      <Providers addTypename={false} mocks={mocks}>
+        <AskNotificationsConnected
+          Component={CustomComponent}
+          onPressPrimary={jest.fn()}
+        />
+      </Providers>
+    );
+    expect(tree).toMatchSnapshot();
+  });
   it('should render with no data in the cache', () => {
     const tree = renderer.create(
       <Providers>

--- a/packages/apollos-ui-onboarding/src/slides/AskNotifications/__snapshots__/AskNotificationsConnected.tests.js.snap
+++ b/packages/apollos-ui-onboarding/src/slides/AskNotifications/__snapshots__/AskNotificationsConnected.tests.js.snap
@@ -1,5 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`The Onboarding AskNotificationsConnected component should render a custom Component 1`] = `
+<RCTSafeAreaView
+  emulateUnlessSupported={true}
+  onLayout={[Function]}
+  style={
+    Object {
+      "bottom": 0,
+      "left": 0,
+      "position": "absolute",
+      "right": 0,
+      "top": 0,
+    }
+  }
+>
+  <View
+    onLayout={[Function]}
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  >
+    <Text>
+      Skyline &gt; Goldstar === true
+    </Text>
+  </View>
+</RCTSafeAreaView>
+`;
+
 exports[`The Onboarding AskNotificationsConnected component should render as if a user had granted push notifications permissions 1`] = `
 <RCTSafeAreaView
   emulateUnlessSupported={true}

--- a/packages/apollos-ui-onboarding/src/slides/AskNotifications/__snapshots__/AskNotificationsConnected.tests.js.snap
+++ b/packages/apollos-ui-onboarding/src/slides/AskNotifications/__snapshots__/AskNotificationsConnected.tests.js.snap
@@ -34,7 +34,7 @@ exports[`The Onboarding AskNotificationsConnected component should render a cust
     }
   >
     <Text>
-      Skyline &gt; Goldstar === true
+      Skyline is better than Goldstar === true
     </Text>
   </View>
 </RCTSafeAreaView>

--- a/packages/apollos-ui-onboarding/src/slides/Features/FeaturesConnected.js
+++ b/packages/apollos-ui-onboarding/src/slides/Features/FeaturesConnected.js
@@ -24,7 +24,7 @@ const FeaturesConnected = ({ Component, ...props }) => (
 );
 
 FeaturesConnected.propTypes = {
-  Component: PropTypes.node,
+  Component: PropTypes.node, // Custom component to be rendered. Defaults to Features
 };
 
 FeaturesConnected.defaultProps = {

--- a/packages/apollos-ui-onboarding/src/slides/Features/FeaturesConnected.js
+++ b/packages/apollos-ui-onboarding/src/slides/Features/FeaturesConnected.js
@@ -24,11 +24,18 @@ const FeaturesConnected = ({ Component, ...props }) => (
 );
 
 FeaturesConnected.propTypes = {
-  Component: PropTypes.node, // Custom component to be rendered. Defaults to Features
+  // Custom component to be rendered. Defaults to Features
+  Component: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.func,
+    PropTypes.object,
+  ]),
 };
 
 FeaturesConnected.defaultProps = {
   Component: Features,
 };
+
+FeaturesConnected.displayName = 'FeaturesConnected';
 
 export default FeaturesConnected;

--- a/packages/apollos-ui-onboarding/src/slides/Features/FeaturesConnected.js
+++ b/packages/apollos-ui-onboarding/src/slides/Features/FeaturesConnected.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import { Query } from 'react-apollo';
+import PropTypes from 'prop-types';
 
 import getUserFirstName from './getUserFirstName';
 import Features from './Features';
 
-const FeaturesConnected = (props) => (
+const FeaturesConnected = ({ Component, ...props }) => (
   <Query query={getUserFirstName}>
     {({
       loading,
@@ -12,7 +13,7 @@ const FeaturesConnected = (props) => (
         currentUser: { profile: { firstName } = { campus: {} } } = {},
       } = {},
     }) => (
-      <Features
+      <Component
         firstName={firstName}
         isLoading={loading}
         pressPrimaryEventName={'Features Completed'}
@@ -21,5 +22,13 @@ const FeaturesConnected = (props) => (
     )}
   </Query>
 );
+
+FeaturesConnected.propTypes = {
+  Component: PropTypes.node,
+};
+
+FeaturesConnected.defaultProps = {
+  Component: Features,
+};
 
 export default FeaturesConnected;

--- a/packages/apollos-ui-onboarding/src/slides/Features/FeaturesConnected.tests.js
+++ b/packages/apollos-ui-onboarding/src/slides/Features/FeaturesConnected.tests.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { Text } from 'react-native';
 import wait from 'waait';
 
-import { Providers } from '../../testUtils';
+import { renderWithApolloData, Providers } from '../../testUtils';
 
 import getUserFirstName from './getUserFirstName';
 import FeaturesConnected from './FeaturesConnected';
@@ -29,6 +30,38 @@ describe('The Onboarding FeaturesConnected component', () => {
       </Providers>
     );
     await wait(0); // wait for response from graphql
+    expect(tree).toMatchSnapshot();
+  });
+  it('should render a custom Component', async () => {
+    const mock = {
+      request: {
+        query: getUserFirstName,
+      },
+      result: {
+        data: {
+          currentUser: {
+            __typename: 'AuthenticatedUser',
+            id: 'AuthenticatedUser:123',
+            profile: {
+              __typename: 'Person',
+              id: 'Person:123',
+              firstName: 'Marty',
+            },
+          },
+        },
+      },
+    };
+
+    // eslint-disable-next-line react/prop-types
+    const CustomComponent = ({ firstName }) => (
+      <Text>{`${firstName} also thinks Skyline chili is the best.`}</Text>
+    );
+
+    const tree = await renderWithApolloData(
+      <Providers mocks={[mock]}>
+        <FeaturesConnected Component={CustomComponent} />
+      </Providers>
+    );
     expect(tree).toMatchSnapshot();
   });
 });

--- a/packages/apollos-ui-onboarding/src/slides/Features/FeaturesConnected.tests.js
+++ b/packages/apollos-ui-onboarding/src/slides/Features/FeaturesConnected.tests.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { Text } from 'react-native';
-import wait from 'waait';
 
 import { renderWithApolloData, Providers } from '../../testUtils';
 
@@ -9,7 +8,15 @@ import getUserFirstName from './getUserFirstName';
 import FeaturesConnected from './FeaturesConnected';
 
 describe('The Onboarding FeaturesConnected component', () => {
-  it('renders with a firstName when logged in', async () => {
+  it('should render', () => {
+    const tree = renderer.create(
+      <Providers>
+        <FeaturesConnected />
+      </Providers>
+    );
+    expect(tree).toMatchSnapshot();
+  });
+  it('should render with a firstName when logged in', async () => {
     const mock = {
       request: {
         query: getUserFirstName,
@@ -17,19 +24,23 @@ describe('The Onboarding FeaturesConnected component', () => {
       result: {
         data: {
           currentUser: {
+            __typename: 'AuthenticatedUser',
+            id: 'AuthenticatedUser:123',
             profile: {
+              __typename: 'Person',
+              id: 'Person:123',
               firstName: 'Marty',
             },
           },
         },
       },
     };
-    const tree = renderer.create(
+
+    const tree = await renderWithApolloData(
       <Providers mocks={[mock]}>
         <FeaturesConnected />
       </Providers>
     );
-    await wait(0); // wait for response from graphql
     expect(tree).toMatchSnapshot();
   });
   it('should render a custom Component', async () => {

--- a/packages/apollos-ui-onboarding/src/slides/Features/__snapshots__/FeaturesConnected.tests.js.snap
+++ b/packages/apollos-ui-onboarding/src/slides/Features/__snapshots__/FeaturesConnected.tests.js.snap
@@ -102,3 +102,43 @@ exports[`The Onboarding FeaturesConnected component renders with a firstName whe
   </View>
 </RCTSafeAreaView>
 `;
+
+exports[`The Onboarding FeaturesConnected component should render a custom Component 1`] = `
+<RCTSafeAreaView
+  emulateUnlessSupported={true}
+  onLayout={[Function]}
+  style={
+    Object {
+      "bottom": 0,
+      "left": 0,
+      "position": "absolute",
+      "right": 0,
+      "top": 0,
+    }
+  }
+>
+  <View
+    onLayout={[Function]}
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  >
+    <Text>
+      Marty also thinks Skyline chili is the best.
+    </Text>
+  </View>
+</RCTSafeAreaView>
+`;

--- a/packages/apollos-ui-onboarding/src/slides/Features/__snapshots__/FeaturesConnected.tests.js.snap
+++ b/packages/apollos-ui-onboarding/src/slides/Features/__snapshots__/FeaturesConnected.tests.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`The Onboarding FeaturesConnected component renders with a firstName when logged in 1`] = `
+exports[`The Onboarding FeaturesConnected component should render 1`] = `
 <RCTSafeAreaView
   emulateUnlessSupported={true}
   onLayout={[Function]}
@@ -139,6 +139,109 @@ exports[`The Onboarding FeaturesConnected component should render a custom Compo
     <Text>
       Marty also thinks Skyline chili is the best.
     </Text>
+  </View>
+</RCTSafeAreaView>
+`;
+
+exports[`The Onboarding FeaturesConnected component should render with a firstName when logged in 1`] = `
+<RCTSafeAreaView
+  emulateUnlessSupported={true}
+  onLayout={[Function]}
+  style={
+    Object {
+      "bottom": 0,
+      "left": 0,
+      "position": "absolute",
+      "right": 0,
+      "top": 0,
+    }
+  }
+>
+  <View
+    onLayout={[Function]}
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  >
+    <RCTScrollView
+      contentContainerStyle={
+        Object {
+          "minHeight": "100%",
+        }
+      }
+      overScrollMode="auto"
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
+      <View>
+        <RCTSafeAreaView
+          emulateUnlessSupported={true}
+          forceInset={
+            Object {
+              "bottom": "always",
+            }
+          }
+          style={
+            Object {
+              "marginBottom": 48,
+              "paddingHorizontal": 16,
+              "paddingTop": 16,
+            }
+          }
+        >
+          <View>
+            <View
+              style={
+                Object {
+                  "paddingBottom": 8,
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "color": "#00676D",
+                    "fontFamily": "InterUI-Black",
+                    "fontSize": 36,
+                    "lineHeight": 41.4,
+                  }
+                }
+              >
+                Hey Marty!
+              </Text>
+            </View>
+            <Text
+              style={
+                Object {
+                  "color": "#505050",
+                  "fontFamily": "InterUI-Medium",
+                  "fontSize": 14,
+                  "lineHeight": 20.16,
+                }
+              }
+            >
+              We'd like to help personalize your mobile experience so we can help you with every step on your journey.
+            </Text>
+          </View>
+        </RCTSafeAreaView>
+      </View>
+    </RCTScrollView>
   </View>
 </RCTSafeAreaView>
 `;

--- a/packages/apollos-ui-onboarding/src/slides/LocationFinder/LocationFinderConnected.js
+++ b/packages/apollos-ui-onboarding/src/slides/LocationFinder/LocationFinderConnected.js
@@ -9,6 +9,7 @@ class LocationFinderConnected extends PureComponent {
   state = { selectedCampus: false };
 
   render() {
+    // const { Component } = this.props;
     return (
       <Query query={getUserCampus} fetchPolicy="cache-and-network">
         {({
@@ -22,7 +23,7 @@ class LocationFinderConnected extends PureComponent {
         }) => (
           <AnalyticsConsumer>
             {({ track }) => (
-              <LocationFinder
+              <this.props.Component
                 onPressButton={async () => {
                   this.setState({ selectedCampus: true });
                   this.props.onNavigate();
@@ -53,8 +54,13 @@ class LocationFinderConnected extends PureComponent {
 }
 
 LocationFinderConnected.propTypes = {
+  Component: PropTypes.node,
   onPressPrimary: PropTypes.func,
   onNavigate: PropTypes.func.isRequired,
+};
+
+LocationFinderConnected.defaultProps = {
+  Component: LocationFinder,
 };
 
 LocationFinderConnected.displayName = 'LocationFinderConnected';

--- a/packages/apollos-ui-onboarding/src/slides/LocationFinder/LocationFinderConnected.js
+++ b/packages/apollos-ui-onboarding/src/slides/LocationFinder/LocationFinderConnected.js
@@ -9,7 +9,6 @@ class LocationFinderConnected extends PureComponent {
   state = { selectedCampus: false };
 
   render() {
-    // const { Component } = this.props;
     return (
       <Query query={getUserCampus} fetchPolicy="cache-and-network">
         {({
@@ -54,7 +53,12 @@ class LocationFinderConnected extends PureComponent {
 }
 
 LocationFinderConnected.propTypes = {
-  Component: PropTypes.node, // Custom component to be rendered. Defaults to LocationFinder
+  // Custom component to be rendered. Defaults to LocationFinder
+  Component: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.func,
+    PropTypes.object,
+  ]),
   onPressPrimary: PropTypes.func,
   onNavigate: PropTypes.func.isRequired,
 };

--- a/packages/apollos-ui-onboarding/src/slides/LocationFinder/LocationFinderConnected.js
+++ b/packages/apollos-ui-onboarding/src/slides/LocationFinder/LocationFinderConnected.js
@@ -54,7 +54,7 @@ class LocationFinderConnected extends PureComponent {
 }
 
 LocationFinderConnected.propTypes = {
-  Component: PropTypes.node,
+  Component: PropTypes.node, // Custom component to be rendered. Defaults to LocationFinder
   onPressPrimary: PropTypes.func,
   onNavigate: PropTypes.func.isRequired,
 };

--- a/packages/apollos-ui-onboarding/src/slides/LocationFinder/LocationFinderConnected.tests.js
+++ b/packages/apollos-ui-onboarding/src/slides/LocationFinder/LocationFinderConnected.tests.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { Text } from 'react-native';
+
 import { Providers, renderWithApolloData } from '../../testUtils';
 
 import LocationFinderConnected from './LocationFinderConnected';
@@ -26,6 +28,49 @@ describe('The Onboarding LocationFinderConnected component', () => {
     );
 
     const tree = await renderWithApolloData(component);
+    expect(tree).toMatchSnapshot();
+  });
+  it('should render a custom component', async () => {
+    const mocks = [
+      {
+        request: {
+          query: getUserCampus,
+        },
+        result: {
+          data: {
+            campus: {
+              campus: {
+                id: 'Campus:a0f64573eabf00a607bec911794d50fb',
+                name: 'Chicago Campus',
+                latitude: 42.09203,
+                longitude: -88.13289,
+                distanceFromLocation: null,
+                street1: '67 Algonquin Rd',
+                street2: '',
+                city: 'South Barrington',
+                state: 'IL',
+                postalCode: '60010-6143',
+                image: {
+                  uri:
+                    'https://res.cloudinary.com/apollos/image/fetch/c_limit,f_auto,w_1600/https://apollosrock.newspring.cc/GetImage.ashx%3Fguid%3Dede1fb83-968e-4bef-8d77-ad81c96e8a47',
+                },
+              },
+            },
+          },
+        },
+      },
+    ];
+
+    // eslint-disable-next-line react/prop-types
+    const CustomComponent = ({ buttonText }) => (
+      <Text>{`${buttonText} nearest a Skyline chili.`}</Text>
+    );
+
+    const tree = await renderWithApolloData(
+      <Providers mocks={mocks} addTypename={false}>
+        <LocationFinderConnected Component={CustomComponent} />
+      </Providers>
+    );
     expect(tree).toMatchSnapshot();
   });
   it('should render with a user having selected a campus', async () => {

--- a/packages/apollos-ui-onboarding/src/slides/LocationFinder/__snapshots__/LocationFinderConnected.tests.js.snap
+++ b/packages/apollos-ui-onboarding/src/slides/LocationFinder/__snapshots__/LocationFinderConnected.tests.js.snap
@@ -1,5 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`The Onboarding LocationFinderConnected component should render a custom component 1`] = `
+<RCTSafeAreaView
+  emulateUnlessSupported={true}
+  onLayout={[Function]}
+  style={
+    Object {
+      "bottom": 0,
+      "left": 0,
+      "position": "absolute",
+      "right": 0,
+      "top": 0,
+    }
+  }
+>
+  <View
+    onLayout={[Function]}
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  >
+    <Text>
+      Yes, find my local campus nearest a Skyline chili.
+    </Text>
+  </View>
+</RCTSafeAreaView>
+`;
+
 exports[`The Onboarding LocationFinderConnected component should render with a user having selected a campus 1`] = `
 <RCTSafeAreaView
   emulateUnlessSupported={true}
@@ -34,6 +74,31 @@ exports[`The Onboarding LocationFinderConnected component should render with a u
     }
   >
     <RCTScrollView
+      Component={
+        Object {
+          "$$typeof": Symbol(react.memo),
+          "compare": null,
+          "defaultProps": Object {
+            "buttonDisabled": false,
+            "buttonText": "Yes, find my local campus",
+            "description": "We'll use your location to connect you with your nearby campus and community",
+            "slideTitle": "Let's select your local campus",
+          },
+          "displayName": "LocationFinder",
+          "propTypes": Object {
+            "BackgroundComponent": [Function],
+            "buttonDisabled": [Function],
+            "buttonText": [Function],
+            "campus": [Function],
+            "description": [Function],
+            "isCurrentCampus": [Function],
+            "onPressButton": [Function],
+            "onPressPrimary": [Function],
+            "slideTitle": [Function],
+          },
+          "type": [Function],
+        }
+      }
       contentContainerStyle={
         Object {
           "minHeight": "100%",
@@ -200,6 +265,31 @@ exports[`The Onboarding LocationFinderConnected component should render with a u
     }
   >
     <RCTScrollView
+      Component={
+        Object {
+          "$$typeof": Symbol(react.memo),
+          "compare": null,
+          "defaultProps": Object {
+            "buttonDisabled": false,
+            "buttonText": "Yes, find my local campus",
+            "description": "We'll use your location to connect you with your nearby campus and community",
+            "slideTitle": "Let's select your local campus",
+          },
+          "displayName": "LocationFinder",
+          "propTypes": Object {
+            "BackgroundComponent": [Function],
+            "buttonDisabled": [Function],
+            "buttonText": [Function],
+            "campus": [Function],
+            "description": [Function],
+            "isCurrentCampus": [Function],
+            "onPressButton": [Function],
+            "onPressPrimary": [Function],
+            "slideTitle": [Function],
+          },
+          "type": [Function],
+        }
+      }
       contentContainerStyle={
         Object {
           "minHeight": "100%",
@@ -370,6 +460,31 @@ exports[`The Onboarding LocationFinderConnected component should render with no 
     }
   >
     <RCTScrollView
+      Component={
+        Object {
+          "$$typeof": Symbol(react.memo),
+          "compare": null,
+          "defaultProps": Object {
+            "buttonDisabled": false,
+            "buttonText": "Yes, find my local campus",
+            "description": "We'll use your location to connect you with your nearby campus and community",
+            "slideTitle": "Let's select your local campus",
+          },
+          "displayName": "LocationFinder",
+          "propTypes": Object {
+            "BackgroundComponent": [Function],
+            "buttonDisabled": [Function],
+            "buttonText": [Function],
+            "campus": [Function],
+            "description": [Function],
+            "isCurrentCampus": [Function],
+            "onPressButton": [Function],
+            "onPressPrimary": [Function],
+            "slideTitle": [Function],
+          },
+          "type": [Function],
+        }
+      }
       contentContainerStyle={
         Object {
           "minHeight": "100%",


### PR DESCRIPTION
## DESCRIPTION
> "Our coding architecture encourages simple modular pure components that can be reused that are "driven by a ConnectedComponent. Currently connected components are hardcoded and tied to render their pure "child" component that they fetch data for. This makes it impossible to reuse them or customize the rendered child while keeping the ConnectedComponent unchanged resulting in unnecessary copy/paste and code debt." – #774 

### What does this PR do, or why is it needed?
This PR adds a `Component` prop to all of the onboarding ConnectedComponents.

### What design trade-offs/decisions were made?
None. All of the ConnectedComponents just default to the components they previously were rendering as children.

### How do I test this PR?
Open app launch onboarding. Everything works? Your good!

### What automated tests did you write?
The new `Component` prop has 100% snapshot coverage 💥

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Partial work towards #774 
- [x] No new warnings in tests, in storybook, and in-app
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
