### PR TITLE
Remove required flag from certain schema attributes 

### DIFF
--- a/packages/apollos-church-api/local.graphql
+++ b/packages/apollos-church-api/local.graphql
@@ -85,7 +85,7 @@ scalar Color
 
 type ContentChannel implements Node {
   id: ID!
-  name: String!
+  name: String
   description: String
   childContentChannels: [ContentChannel]
   childContentItemsConnection(first: Int, after: String): ContentItemsConnection
@@ -257,8 +257,8 @@ type PaginationInfo {
 
 type Pass implements Node {
   id: ID!
-  type: PassType!
-  description: String!
+  type: PassType
+  description: String
   logo: ImageMediaSource
   thumbnail: ImageMediaSource
   barcode: ImageMediaSource
@@ -291,7 +291,7 @@ enum PassType {
 
 type Person implements Node {
   id: ID!
-  firstName: String!
+  firstName: String
   lastName: String!
   nickName: String
   email: String

--- a/packages/apollos-data-schema/src/index.js
+++ b/packages/apollos-data-schema/src/index.js
@@ -61,7 +61,7 @@ export const peopleSchema = gql`
 
   type Person implements Node @cacheControl(maxAge: 0) {
     id: ID!
-    firstName: String!
+    firstName: String
     lastName: String!
     nickName: String
     email: String
@@ -357,7 +357,7 @@ export const contentItemSchema = gql`
 export const contentChannelSchema = gql`
   type ContentChannel implements Node {
     id: ID!
-    name: String!
+    name: String
     description: String
 
     childContentChannels: [ContentChannel]
@@ -480,8 +480,8 @@ export const passSchema = gql`
 
   type Pass implements Node {
     id: ID!
-    type: PassType!
-    description: String!
+    type: PassType
+    description: String
     logo: ImageMediaSource
     thumbnail: ImageMediaSource
     barcode: ImageMediaSource


### PR DESCRIPTION
## DESCRIPTION

I have found that having attributes marked as required can be brittle, for example, parts of our app now throw errors if you don't put in a first name on onboarding. Technically a first name is not great, but GraphQL shouldn't be throwing errors just trying to query for it.

### What does this PR do, or why is it needed?

Removes the required marker from `attributes` on types in the schema that have the marker. 

### What design trade-offs/decisions were made?

Schema no longer reflects "base case scenario" for data cleanliness as closely. 

### How do I test this PR?

1. Boot the app, it shouldn't fail.
2. Create a new user and opt to avoid setting a first name. The app will no longer throw an error.

### What automated tests did you write?

n/a

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [x] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
