### PR TITLE
Fixes Parent Image Algorithm

### DIFF
--- a/packages/apollos-data-connector-rock/src/content-items/data-source.js
+++ b/packages/apollos-data-connector-rock/src/content-items/data-source.js
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import { get, flatten } from 'lodash';
 import RockApolloDataSource from '@apollosproject/rock-apollo-data-source';
 import ApollosConfig from '@apollosproject/config';
 import moment from 'moment-timezone';
@@ -128,9 +128,11 @@ export default class ContentItem extends RockApolloDataSource {
       return { ...images[0], __typename: 'ImageMedia' };
     };
 
-    const ourImages = this.getImages(root).filter(
-      (image) => image.sources.length
-    ); // filter images w/o URLs
+    const withSources = (image) => image.sources.length;
+
+    // filter images w/o URLs
+    const ourImages = this.getImages(root).filter(withSources);
+
     if (ourImages.length) return pickBestImage(ourImages);
 
     // If no image, check parent for image:
@@ -140,21 +142,8 @@ export default class ContentItem extends RockApolloDataSource {
     const parentItems = await parentItemsCursor.get();
 
     if (parentItems.length) {
-      const parentImages = parentItems
-        .map(this.getImages)
-        .filter(
-          (parent) =>
-            parent
-              .map((image) => image.sources)
-              .filter((sources) => sources.length).length
-        )
-        .find((images) => images.length);
-
-      if (!parentImages) return null;
-
-      const validParentImages = parentImages.filter(
-        (image) => image.sources.length
-      );
+      const parentImages = flatten(parentItems.map(this.getImages));
+      const validParentImages = parentImages.filter(withSources);
 
       if (validParentImages && validParentImages.length)
         return pickBestImage(validParentImages);

--- a/packages/apollos-data-connector-rock/src/content-items/data-source.js
+++ b/packages/apollos-data-connector-rock/src/content-items/data-source.js
@@ -142,6 +142,12 @@ export default class ContentItem extends RockApolloDataSource {
     if (parentItems.length) {
       const parentImages = parentItems
         .map(this.getImages)
+        .filter(
+          (parent) =>
+            parent
+              .map((image) => image.sources)
+              .filter((sources) => sources.length).length
+        )
         .find((images) => images.length);
 
       if (!parentImages) return null;


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Changes the algorithm for finding the parent images of Rock content slightly. Specific to instances where a piece of content has multiple parent content channels (campaign and sermon series). It’s looking at the _first_ parent to get images from. So it will fail if this is ever the case:

1. campaign -> no images
2. sermon series

### What design trade-offs/decisions were made?

None.

### How do I test this PR?

Make sure images show up correctly on multiple different types of content, including ones that have multiple parents.

### What automated tests did you write?

None.

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [x] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._