### PR TITLE
Fixes rock-apollo-datasource null bug

### DIFF
--- a/packages/apollos-data-connector-rock/src/people/resolver.js
+++ b/packages/apollos-data-connector-rock/src/people/resolver.js
@@ -1,11 +1,6 @@
 import { createGlobalId } from '@apollosproject/server-core';
 import { enforceCurrentUser } from '../utils';
 
-// Rock returns `{}` instead of `null` for null values.
-// This function eliminates the annoyance of checking those values.
-export const ifNotObject = (field) =>
-  typeof field === 'object' ? null : field;
-
 export default {
   Mutation: {
     updateProfileField: (root, { input: { field, value } }, { dataSources }) =>
@@ -19,11 +14,9 @@ export default {
     id: ({ id }, args, context, { parentType }) =>
       createGlobalId(id, parentType.name),
     photo: ({ photo: { url } }) => ({ uri: url }),
-    firstName: ({ firstName }) => ifNotObject(firstName),
-    lastName: ({ lastName }) => ifNotObject(lastName),
-    birthDate: enforceCurrentUser(({ birthDate }) => ifNotObject(birthDate)),
+    birthDate: enforceCurrentUser(({ birthDate }) => birthDate),
     gender: enforceCurrentUser(({ gender }) => gender),
-    email: enforceCurrentUser(({ email }) => ifNotObject(email)),
+    email: enforceCurrentUser(({ email }) => email),
   },
   GENDER: {
     Unknown: 0,

--- a/packages/apollos-rock-apollo-data-source/src/index.js
+++ b/packages/apollos-rock-apollo-data-source/src/index.js
@@ -47,7 +47,7 @@ export default class RockApolloDataSource extends RESTDataSource {
 
   normalize = (data) => {
     if (Array.isArray(data)) return data.map(this.normalize);
-    if (typeof data !== 'object') return data;
+    if (typeof data !== 'object' || data === null) return data;
     const normalizedValues = mapValues(data, this.normalize);
     return mapKeys(normalizedValues, (value, key) => camelCase(key));
   };


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

"Rock" was returning `{}` for values that were actually `null`. Turns out we were treating `null` as an object to be traversed, causing this issue. 

### What design trade-offs/decisions were made?

n/a

### How do I test this PR?

Check the automated tests. Should be no changes in how the API serves data. Endpoints that were doing manual checking of null values won't have their implementation change. 

### What automated tests did you write?

Wrote a test to cover the `normalizer` in the Rock Apollo Datasource.

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [x] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
