### PR TITLE
Adds API support for content items to have livestreams

### DIFF
--- a/packages/apollos-church-api/config.yml
+++ b/packages/apollos-church-api/config.yml
@@ -23,6 +23,8 @@ ONE_SIGNAL:
   REST_KEY: ${ONE_SIGNAL_REST_KEY}
 CHURCH_ONLINE:
   URL: https://apollos.churchonline.org/api/v1/
+  MEDIA_URLS: []
+  WEB_VIEW_URL: https://apollos.churchonline.org/
 TWILIO:
   ACCOUNT_SID: ${TWILIO_ACCOUNT_SID}
   AUTH_TOKEN: ${TWILIO_AUTH_TOKEN}
@@ -73,6 +75,7 @@ ROCK_MAPPINGS:
     UniversalContentItem:
       EntityType: ContentChannelItem
     WeekendContentItem:
+      ContentChannelId: [5]
       EntityType: ContentChannelItem
     ContentItem:
       EntityType: ContentChannelItem
@@ -101,6 +104,8 @@ ROCK_MAPPINGS:
 
   CAMPAIGN_CHANNEL_IDS:
     - 11
+
+  SERMON_CHANNEL_ID: 5
 
   HOME_FEATURE_CHANNEL_ID: 13
 

--- a/packages/apollos-church-api/local.graphql
+++ b/packages/apollos-church-api/local.graphql
@@ -219,6 +219,8 @@ input LikeEntityInput {
 type LiveStream {
   isLive: Boolean
   eventStartTime: String
+  media: VideoMedia
+  webViewUrl: String
 }
 
 interface Media {
@@ -458,6 +460,7 @@ type WeekendContentItem implements ContentItem & Node {
   theme: Theme
   isLiked: Boolean
   likedCount: Int
+  liveStream: LiveStream
   sharing: SharableContentItem
   features: [Feature]
 }

--- a/packages/apollos-data-connector-church-online/src/__tests__/__snapshots__/resolver.tests.js.snap
+++ b/packages/apollos-data-connector-church-online/src/__tests__/__snapshots__/resolver.tests.js.snap
@@ -6,6 +6,14 @@ Object {
     "liveStream": Object {
       "eventStartTime": "2018-08-06T17:00:00Z",
       "isLive": true,
+      "media": Object {
+        "sources": Array [
+          Object {
+            "uri": "https://example.org/video.mp4",
+          },
+        ],
+      },
+      "webViewUrl": null,
     },
   },
 }

--- a/packages/apollos-data-connector-church-online/src/__tests__/resolver.tests.js
+++ b/packages/apollos-data-connector-church-online/src/__tests__/resolver.tests.js
@@ -44,6 +44,10 @@ describe('LiveStream', () => {
         liveStream {
           isLive
           eventStartTime
+          media {
+            sources { uri }
+          }
+          webViewUrl
         }
       }
     `;

--- a/packages/apollos-data-connector-church-online/src/__tests__/resolver.tests.js
+++ b/packages/apollos-data-connector-church-online/src/__tests__/resolver.tests.js
@@ -3,6 +3,12 @@ import { fetch } from 'apollo-server-env';
 import { graphql } from 'graphql';
 import { createTestHelpers } from '@apollosproject/server-core/lib/testUtils';
 import ApollosConfig from '@apollosproject/config';
+import {
+  themeSchema,
+  contentChannelSchema,
+  contentItemSchema,
+  scriptureSchema,
+} from '@apollosproject/data-schema';
 import * as LiveStream from '../index';
 
 ApollosConfig.loadJs({
@@ -12,12 +18,19 @@ ApollosConfig.loadJs({
 });
 // we import the root-level schema and resolver so we test the entire integration:
 
-const { getSchema, getContext } = createTestHelpers({ LiveStream });
+const { getSchema, getContext } = createTestHelpers({
+  LiveStream,
+});
 describe('LiveStream', () => {
   let schema;
   let context;
   beforeEach(() => {
-    schema = getSchema();
+    schema = getSchema([
+      themeSchema,
+      contentChannelSchema,
+      contentItemSchema,
+      scriptureSchema,
+    ]);
     context = getContext();
 
     fetch.resetMocks();

--- a/packages/apollos-data-connector-church-online/src/__tests__/resolver.tests.js
+++ b/packages/apollos-data-connector-church-online/src/__tests__/resolver.tests.js
@@ -14,6 +14,7 @@ import * as LiveStream from '../index';
 ApollosConfig.loadJs({
   CHURCH_ONLINE: {
     URL: 'https://apollos.churchonline.org/api/v1/',
+    MEDIA_URLS: ['https://example.org/video.mp4'],
   },
 });
 // we import the root-level schema and resolver so we test the entire integration:

--- a/packages/apollos-data-connector-church-online/src/data-source.js
+++ b/packages/apollos-data-connector-church-online/src/data-source.js
@@ -15,7 +15,6 @@ export default class LiveStream extends RESTDataSource {
   }
 
   get webViewUrl() {
-    // return 'tet';
     return ApollosConfig.CHURCH_ONLINE.WEB_VIEW_URL;
   }
 
@@ -24,7 +23,7 @@ export default class LiveStream extends RESTDataSource {
     return {
       isLive: get(stream, 'response.item.isLive', false),
       eventStartTime: get(stream, 'response.item.eventStartTime'),
-      streamMedia: () =>
+      media: () =>
         this.mediaUrls.length
           ? {
               sources: this.mediaUrls.map((uri) => ({

--- a/packages/apollos-data-connector-church-online/src/data-source.js
+++ b/packages/apollos-data-connector-church-online/src/data-source.js
@@ -1,6 +1,7 @@
 /* eslint-disable class-methods-use-this */
 import { RESTDataSource } from 'apollo-datasource-rest';
 import ApollosConfig from '@apollosproject/config';
+import { get } from 'lodash';
 
 export default class LiveStream extends RESTDataSource {
   resource = 'LiveStream';
@@ -9,7 +10,29 @@ export default class LiveStream extends RESTDataSource {
     return ApollosConfig.CHURCH_ONLINE.URL;
   }
 
+  get mediaUrls() {
+    return ApollosConfig.CHURCH_ONLINE.MEDIA_URLS;
+  }
+
+  get webViewUrl() {
+    // return 'tet';
+    return ApollosConfig.CHURCH_ONLINE.WEB_VIEW_URL;
+  }
+
   async getLiveStream() {
-    return this.get('events/current');
+    const stream = await this.get('events/current');
+    return {
+      isLive: get(stream, 'response.item.isLive', false),
+      eventStartTime: get(stream, 'response.item.eventStartTime'),
+      streamMedia: () =>
+        this.mediaUrls.length
+          ? {
+              sources: this.mediaUrls.map((uri) => ({
+                uri,
+              })),
+            }
+          : null,
+      webViewUrl: this.webViewUrl,
+    };
   }
 }

--- a/packages/apollos-data-connector-church-online/src/resolver.js
+++ b/packages/apollos-data-connector-church-online/src/resolver.js
@@ -3,9 +3,4 @@ export default {
     liveStream: (root, args, { dataSources }) =>
       dataSources.LiveStream.getLiveStream(),
   },
-  LiveStream: {
-    isLive: ({ response: { item: { isLive } = {} } = {} }) => isLive,
-    eventStartTime: ({ response: { item: { eventStartTime } = {} } = {} }) =>
-      eventStartTime,
-  },
 };

--- a/packages/apollos-data-connector-rock/src/content-channels/__tests__/resolvers.tests.js
+++ b/packages/apollos-data-connector-rock/src/content-channels/__tests__/resolvers.tests.js
@@ -9,6 +9,7 @@ import {
   mediaSchema,
   themeSchema,
   scriptureSchema,
+  liveSchema,
 } from '@apollosproject/data-schema';
 
 // we import the root-level schema and resolver so we test the entire integration:
@@ -63,7 +64,7 @@ describe('ContentChannel', () => {
   beforeEach(() => {
     fetch.resetMocks();
     fetch.mockRockDataSourceAPI();
-    schema = getSchema([themeSchema, mediaSchema, scriptureSchema]);
+    schema = getSchema([themeSchema, mediaSchema, scriptureSchema, liveSchema]);
     context = getContext();
   });
 

--- a/packages/apollos-data-connector-rock/src/content-items/__tests__/__snapshots__/data-source.tests.js.snap
+++ b/packages/apollos-data-connector-rock/src/content-items/__tests__/__snapshots__/data-source.tests.js.snap
@@ -21,6 +21,16 @@ Array [
 ]
 `;
 
+exports[`ContentItemsModel getSermonFeed fetches items from a specific content channel 1`] = `
+Array [
+  Array [
+    "TEST_ID",
+  ],
+]
+`;
+
+exports[`ContentItemsModel getSermonFeed fetches items from a specific content channel 2`] = `Promise {}`;
+
 exports[`ContentItemsModel gets a cursor finding child content items of a provided parent 1`] = `
 Array [
   Array [
@@ -138,6 +148,20 @@ Array [
   Object {
     "id": 2,
   },
+]
+`;
+
+exports[`ContentItemsModel isContentActiveLiveStream returns false if the livestream is innactive 1`] = `Array []`;
+
+exports[`ContentItemsModel isContentActiveLiveStream returns false if the livestream is not the most recent sermon 1`] = `
+Array [
+  Array [],
+]
+`;
+
+exports[`ContentItemsModel isContentActiveLiveStream returns true if the livestream is the most recent sermon 1`] = `
+Array [
+  Array [],
 ]
 `;
 

--- a/packages/apollos-data-connector-rock/src/content-items/__tests__/__snapshots__/resolvers.tests.js.snap
+++ b/packages/apollos-data-connector-rock/src/content-items/__tests__/__snapshots__/resolvers.tests.js.snap
@@ -276,6 +276,144 @@ Object {
 }
 `;
 
+exports[`UniversalContentItem gets a WeekendContentItem item 1`] = `
+Object {
+  "data": Object {
+    "node": Object {
+      "__typename": "WeekendContentItem",
+      "audios": Array [
+        Object {
+          "__typename": "AudioMedia",
+          "key": "audioLink",
+          "name": "Audio Link",
+          "sources": Array [
+            Object {
+              "__typename": "AudioMediaSource",
+              "uri": "https://rockrms.blob.core.windows.net/sampledata/podcasting/sample.mp3",
+            },
+          ],
+        },
+      ],
+      "childContentItemsConnection": Object {
+        "edges": Array [
+          Object {
+            "cursor": "b487224762b030f470967f45d7205823",
+            "node": Object {
+              "__typename": "MediaContentItem",
+              "id": "MediaContentItem:559b23fd0aa90e81b1c023e72e230fa1",
+            },
+          },
+        ],
+        "pageInfo": Object {
+          "endCursor": "b487224762b030f470967f45d7205823",
+          "startCursor": "b487224762b030f470967f45d7205823",
+        },
+      },
+      "coverImage": Object {
+        "key": "image",
+        "name": "Image",
+        "sources": Array [
+          Object {
+            "uri": "https://apollosrock.newspring.cc/GetImage.ashx?guid=0241ED2F-B527-424C-917C-1142A398711F",
+          },
+        ],
+      },
+      "htmlContent": "<p>
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin sollicitudin condimentum aliquet. In est nulla, lacinia ac dictum et, laoreet vitae elit. Proin tempus tellus ligula, a consequat diam consectetur a. Phasellus luctus velit sed lorem mollis commodo. Nunc sit amet blandit velit. Donec tincidunt congue facilisis. Sed iaculis at neque non porttitor. Phasellus ultrices egestas erat feugiat pellentesque. Duis venenatis, dolor quis fringilla tempus, sem lorem euismod lectus, sed egestas felis magna at felis. Pellentesque ut rhoncus erat, a pulvinar purus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Ut sit amet consequat est. Maecenas et porta dui, non condimentum lectus.</p>
+<p>
+	Suspendisse vel nibh odio. Pellentesque porta sapien ligula, in laoreet diam tempus sed. Morbi nunc erat, mattis eu pulvinar blandit, adipiscing quis magna. Ut quis dui lobortis velit suscipit consectetur. Nulla iaculis fermentum egestas. Aenean venenatis sagittis mauris, sed rhoncus purus accumsan ac. Suspendisse potenti. Sed sed tempor turpis. Duis sit amet nisi nec purus fringilla condimentum. Phasellus non lacus arcu. Donec scelerisque, erat sed tempor elementum, nulla risus scelerisque ante, ac imperdiet velit magna ut quam. Nam tristique orci auctor consequat laoreet. Quisque malesuada metus sed sodales eleifend. Aenean rhoncus, mi sit amet ullamcorper tincidunt, sem sem rutrum felis, in semper enim massa ut sem.</p>
+<p>
+	Vivamus diam urna, cursus in sapien in, porta gravida enim. Cras non fringilla arcu, tincidunt laoreet lacus. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Aliquam volutpat felis quis augue faucibus ultrices. Morbi lobortis vestibulum sodales. Sed tincidunt urna vitae felis ultrices, pharetra placerat quam dignissim. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi vel adipiscing tellus. In vitae sodales diam. Aliquam pharetra orci a porta molestie. In et neque bibendum, viverra leo sit amet, auctor magna. Morbi posuere massa sed metus euismod, et adipiscing sem dictum. Cras eget elementum risus, non imperdiet ligula.</p>
+",
+      "id": "WeekendContentItem:559b23fd0aa90e81b1c023e72e230fa1",
+      "images": Array [
+        Object {
+          "__typename": "ImageMedia",
+          "key": "image",
+          "name": "Image",
+          "sources": Array [
+            Object {
+              "__typename": "ImageMediaSource",
+              "uri": "https://apollosrock.newspring.cc/GetImage.ashx?guid=0241ED2F-B527-424C-917C-1142A398711F",
+            },
+          ],
+        },
+        Object {
+          "__typename": "ImageMedia",
+          "key": "detailImage",
+          "name": "Detail Image",
+          "sources": Array [
+            Object {
+              "__typename": "ImageMediaSource",
+              "uri": "https://apollosrock.newspring.cc/GetImage.ashx?guid=3DA90982-118A-4BFE-9A32-58D9F610090A",
+            },
+          ],
+        },
+        Object {
+          "__typename": "ImageMedia",
+          "key": "imageByUrlTest",
+          "name": "Image By Url Test",
+          "sources": Array [
+            Object {
+              "__typename": "ImageMediaSource",
+              "uri": "https://some-domain.com/some/path/to/image.jpg",
+            },
+          ],
+        },
+        Object {
+          "__typename": "ImageMedia",
+          "key": "imageBySchemalessUrlTest",
+          "name": "Image By Schemaless Url Test",
+          "sources": Array [
+            Object {
+              "__typename": "ImageMediaSource",
+              "uri": "https://some-domain.com/some/path/to/image.jpg",
+            },
+          ],
+        },
+        Object {
+          "__typename": "ImageMedia",
+          "key": "imageUnknownFormat",
+          "name": "Image Of Unknown format",
+          "sources": Array [
+            Object {
+              "__typename": "ImageMediaSource",
+              "uri": "ftp://some-domain.com/some/path/to/image.jpg",
+            },
+          ],
+        },
+      ],
+      "parentChannel": Object {
+        "__typename": "ContentChannel",
+        "id": "ContentChannel:744e1011cfa6a90bb2fbfeb3ecdc1451",
+      },
+      "sharing": Object {
+        "__typename": "SharableContentItem",
+        "message": "",
+        "title": "SAMPLE: Easter",
+        "url": "https://apollosrock.newspring.cc/",
+      },
+      "summary": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+      "title": "SAMPLE: Easter",
+      "videos": Array [
+        Object {
+          "__typename": "VideoMedia",
+          "embedHtml": "<script src=\\"//fast.wistia.com/embed/medias/kqykx8xbzq.jsonp\\" async></script><script src=\\"//fast.wistia.com/assets/external/E-v1.js\\" async></script><div class=\\"wistia_responsive_padding\\" style=\\"padding:56.25% 0 0 0;position:relative;\\"><div class=\\"wistia_responsive_wrapper\\" style=\\"height:100%;left:0;position:absolute;top:0;width:100%;\\"><div class=\\"wistia_embed wistia_async_kqykx8xbzq videoFoam=true\\" style=\\"height:100%;width:100%\\">&nbsp;</div></div></div>",
+          "key": "videoLink",
+          "name": "Video Link",
+          "sources": Array [
+            Object {
+              "__typename": "VideoMediaSource",
+              "uri": "https://rockrms.blob.core.windows.net/sampledata/podcasting/money-wise.mp4",
+            },
+          ],
+        },
+      ],
+    },
+  },
+}
+`;
+
 exports[`UniversalContentItem gets a content item 1`] = `
 Object {
   "data": Object {
@@ -559,6 +697,22 @@ Object {
 `;
 
 exports[`UniversalContentItem gets a devotional item 1`] = `
+Object {
+  "data": Object {
+    "node": Object {
+      "id": "DevotionalContentItem:559b23fd0aa90e81b1c023e72e230fa1",
+      "scriptures": Array [
+        Object {
+          "html": "<p class=\\"p\\"><span data-number=\\"1\\" class=\\"v\\">1</span>The Song of songs, which is Solomon’s.</p>",
+        },
+      ],
+      "title": "SAMPLE: Easter",
+    },
+  },
+}
+`;
+
+exports[`UniversalContentItem gets a devotional item 2`] = `
 Object {
   "data": Object {
     "node": Object {

--- a/packages/apollos-data-connector-rock/src/content-items/__tests__/resolvers.tests.js
+++ b/packages/apollos-data-connector-rock/src/content-items/__tests__/resolvers.tests.js
@@ -11,6 +11,7 @@ import {
   mediaSchema,
   themeSchema,
   scriptureSchema,
+  liveSchema,
 } from '@apollosproject/data-schema';
 
 import * as RockConstants from '../../rock-constants';
@@ -169,7 +170,7 @@ describe('UniversalContentItem', () => {
   beforeEach(() => {
     fetch.resetMocks();
     fetch.mockRockDataSourceAPI();
-    schema = getSchema([themeSchema, mediaSchema, scriptureSchema]);
+    schema = getSchema([themeSchema, mediaSchema, scriptureSchema, liveSchema]);
 
     const token = generateToken({ cookie: 'some-cookie', sessionId: 123 });
     context = getContext({

--- a/packages/apollos-data-connector-rock/src/content-items/__tests__/resolvers.tests.js
+++ b/packages/apollos-data-connector-rock/src/content-items/__tests__/resolvers.tests.js
@@ -298,6 +298,40 @@ describe('UniversalContentItem', () => {
     expect(result).toMatchSnapshot();
   });
 
+  it('gets a WeekendContentItem item', async () => {
+    const query = `
+      query {
+        node(id: "${createGlobalId(1, 'WeekendContentItem')}") {
+          ...ContentItemFragment
+        }
+      }
+      ${contentItemFragment}
+    `;
+    const rootValue = {};
+    const result = await graphql(schema, query, rootValue, context);
+    expect(result).toMatchSnapshot();
+  });
+
+  it('gets a devotional item', async () => {
+    const query = `
+      query {
+        node(id: "${createGlobalId(123, 'DevotionalContentItem')}") {
+          id
+          ... on DevotionalContentItem {
+            id
+            title
+            scriptures {
+              html
+            }
+          }
+        }
+      }
+    `;
+    const rootValue = {};
+    const result = await graphql(schema, query, rootValue, context);
+    expect(result).toMatchSnapshot();
+  });
+
   it("gets a content item and it's siblings", async () => {
     const query = `
       query {

--- a/packages/apollos-data-connector-rock/src/content-items/data-source.js
+++ b/packages/apollos-data-connector-rock/src/content-items/data-source.js
@@ -136,7 +136,7 @@ export default class ContentItem extends RockApolloDataSource {
     return this.byContentChannelId(ROCK_MAPPINGS.SERMON_CHANNEL_ID);
   }
 
-  async isContentActiveSermon({ id }) {
+  async isContentActiveLiveStream({ id }) {
     const { LiveStream } = this.context.dataSources;
     const { isLive } = await LiveStream.getLiveStream();
     // if there is no live stream, then there is no live content. Easy enough!

--- a/packages/apollos-data-connector-rock/src/content-items/data-source.js
+++ b/packages/apollos-data-connector-rock/src/content-items/data-source.js
@@ -132,6 +132,22 @@ export default class ContentItem extends RockApolloDataSource {
     )[0];
   };
 
+  getSermonFeed() {
+    return this.byContentChannelId(ROCK_MAPPINGS.SERMON_CHANNEL_ID);
+  }
+
+  async isContentActiveSermon({ id }) {
+    const { LiveStream } = this.context.dataSources;
+    const { isLive } = await LiveStream.getLiveStream();
+    // if there is no live stream, then there is no live content. Easy enough!
+    if (!isLive) return false;
+
+    const mostRecentSermon = await this.getSermonFeed().first();
+
+    // If the most recent sermon is the sermon we are checking, this is the live sermon.
+    return mostRecentSermon.id === id;
+  }
+
   async getCoverImage(root) {
     const pickBestImage = (images) => {
       // TODO: there's probably a _much_ more explicit and better way to handle this
@@ -305,7 +321,12 @@ export default class ContentItem extends RockApolloDataSource {
       .find(id)
       .get();
 
-  resolveType({ attributeValues, attributes, contentChannelTypeId }) {
+  resolveType({
+    attributeValues,
+    attributes,
+    contentChannelTypeId,
+    contentChannelId,
+  }) {
     // if we have defined an ContentChannelTypeId based maping in the YML file, use it!
     if (
       Object.values(ROCK_MAPPINGS.CONTENT_ITEM).some(
@@ -319,6 +340,21 @@ export default class ContentItem extends RockApolloDataSource {
         return (
           value.ContentChannelTypeId &&
           value.ContentChannelTypeId.includes(contentChannelTypeId)
+        );
+      });
+    }
+    // if we have defined a ContentChannelId based maping in the YML file, use it!
+    if (
+      Object.values(ROCK_MAPPINGS.CONTENT_ITEM).some(
+        ({ ContentChannelId }) =>
+          ContentChannelId && ContentChannelId.includes(contentChannelId)
+      )
+    ) {
+      return Object.keys(ROCK_MAPPINGS.CONTENT_ITEM).find((key) => {
+        const value = ROCK_MAPPINGS.CONTENT_ITEM[key];
+        return (
+          value.ContentChannelId &&
+          value.ContentChannelId.includes(contentChannelId)
         );
       });
     }

--- a/packages/apollos-data-connector-rock/src/content-items/resolver.js
+++ b/packages/apollos-data-connector-rock/src/content-items/resolver.js
@@ -93,6 +93,14 @@ const resolver = {
   },
   WeekendContentItem: {
     ...defaultContentItemResolvers,
+    liveStream: async (
+      root,
+      args,
+      { dataSources: { ContentItem, LiveStream } }
+    ) => ({
+      ...(await LiveStream.getLiveStream()), // TODO: Wish there was a better way to inherit these defaults from the LiveStream module.
+      isLive: await ContentItem.isContentActiveSermon(root), // We need to override the global IsLive with an IsLive that is contextual to a ContentItem
+    }),
   },
   ContentItem: {
     ...defaultContentItemResolvers,

--- a/packages/apollos-data-connector-rock/src/content-items/resolver.js
+++ b/packages/apollos-data-connector-rock/src/content-items/resolver.js
@@ -99,7 +99,7 @@ const resolver = {
       { dataSources: { ContentItem, LiveStream } }
     ) => ({
       ...(await LiveStream.getLiveStream()), // TODO: Wish there was a better way to inherit these defaults from the LiveStream module.
-      isLive: await ContentItem.isContentActiveSermon(root), // We need to override the global IsLive with an IsLive that is contextual to a ContentItem
+      isLive: await ContentItem.isContentActiveLiveStream(root), // We need to override the global IsLive with an IsLive that is contextual to a ContentItem
     }),
   },
   ContentItem: {

--- a/packages/apollos-data-schema/src/index.js
+++ b/packages/apollos-data-schema/src/index.js
@@ -418,9 +418,15 @@ export const liveSchema = gql`
   type LiveStream {
     isLive: Boolean
     eventStartTime: String
+    media: VideoMedia
+    webViewUrl: String
   }
 
   extend type Query {
+    liveStream: LiveStream
+  }
+
+  extend type WeekendContentItem {
     liveStream: LiveStream
   }
 `;


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

This PR adds some API functionality so that LiveStreams can be associated with ContentItems. Per discussion with @FrankGrand, the following logic is used to determine if a content item has a "live" livestream. 

- If the stream isn't currently live, no content items are live.
- If the stream is live
  - The content item is live if the content item is the most recent sermon content item
  - The content item is **not** live if there are more recent sermon content items than the current content item.

I also attach the `webViewUrl` and a `VideoMedia` to the livestream type.

### What design trade-offs/decisions were made?

- I chose to enhance the API design of the ChurchOnline resolver, by moving most functionality to the dataSource. 

- I added a new attribute to the config.yml for the content channel that holds your sermons.

- I added the capability to define ContentItem TypeNames via `ContentChannelIds` as well as `ContentChannelTypeIds`


### How do I test this PR?

Run the following query: 

```
query userFeed {
  userFeed {
    edges {
      node {
        id
        title
        __typename
        ... on WeekendContentItem {
          liveStream {
            isLive
            media {
              sources {uri}
            }
                          webViewUrl
          }
        }
      }
    }
  }
}
```

You should see that one of the ContentItems (the most recent one) should have `isLive: true` IF the livestream is currently live. You can hardcode the livestream to be live by hardcoding `isLive` here:  https://github.com/ApollosProject/apollos-prototype/blob/839-livestream-attribute-on-content-item/packages/apollos-data-connector-church-online/src/data-source.js#L24

### What automated tests did you write?

Tests over new dataSource methods.

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] References #839
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._

![image](https://user-images.githubusercontent.com/1637694/60912138-b3425e80-a252-11e9-9b1e-40a7a634eeb5.png)
