### PR TITLE
Auth issues

### DIFF
--- a/packages/apollos-data-connector-rock/src/auth/__tests__/__snapshots__/index.tests.js.snap
+++ b/packages/apollos-data-connector-rock/src/auth/__tests__/__snapshots__/index.tests.js.snap
@@ -114,7 +114,7 @@ exports[`Auth registers an auth token and passes the cookie on requests to rock 
 Headers {
   Symbol(map): Object {
     "Authorization-Token": Array [
-      "some-rock-token",
+      "null",
     ],
     "Content-Type": Array [
       "application/json",

--- a/packages/apollos-data-connector-rock/src/auth/data-source.js
+++ b/packages/apollos-data-connector-rock/src/auth/data-source.js
@@ -21,9 +21,12 @@ export default class AuthDataSource extends RockApolloDataSource {
     }
 
     if (userCookie) {
+      // We set this magic "userRequest" property to ensure that the request isn't made on behalf of the Apollos API.
+      this.userRequest = true;
       const request = await this.request('People/GetCurrentPerson').get({
         options: { headers: { cookie: userCookie } },
       });
+      this.userRequest = false;
       this.context.currentPerson = request;
       return request;
     }

--- a/packages/apollos-data-connector-rock/src/auth/data-source.js
+++ b/packages/apollos-data-connector-rock/src/auth/data-source.js
@@ -21,12 +21,11 @@ export default class AuthDataSource extends RockApolloDataSource {
     }
 
     if (userCookie) {
-      // We set this magic "userRequest" property to ensure that the request isn't made on behalf of the Apollos API.
-      this.userRequest = true;
       const request = await this.request('People/GetCurrentPerson').get({
-        options: { headers: { cookie: userCookie } },
+        options: {
+          headers: { cookie: userCookie, 'Authorization-Token': null },
+        },
       });
-      this.userRequest = false;
       this.context.currentPerson = request;
       return request;
     }

--- a/packages/apollos-data-connector-rock/src/auth/token.js
+++ b/packages/apollos-data-connector-rock/src/auth/token.js
@@ -15,6 +15,9 @@ export const registerToken = (token) => {
       sessionId,
     };
   } catch (e) {
+    if (e instanceof jwt.TokenExpiredError) {
+      return {};
+    }
     throw new AuthenticationError('Invalid token');
   }
 };

--- a/packages/apollos-rock-apollo-data-source/src/index.js
+++ b/packages/apollos-rock-apollo-data-source/src/index.js
@@ -22,14 +22,7 @@ export default class RockApolloDataSource extends RESTDataSource {
 
   baseURL = ROCK.API_URL;
 
-  userRequest = false;
-
-  get rockToken() {
-    if (!this.userRequest) {
-      return ROCK.API_TOKEN;
-    }
-    return null;
-  }
+  rockToken = ROCK.API_TOKEN;
 
   nodeFetch = fetch;
 
@@ -47,7 +40,9 @@ export default class RockApolloDataSource extends RESTDataSource {
     }
     this.calls[request.path] = this.calls[request.path] + 1;
 
-    request.headers.set('Authorization-Token', this.rockToken);
+    if (!request.headers.has('Authorization-Token')) {
+      request.headers.set('Authorization-Token', this.rockToken);
+    }
     request.headers.set('user-agent', 'Apollos');
     request.headers.set('Content-Type', 'application/json');
   }

--- a/packages/apollos-rock-apollo-data-source/src/index.js
+++ b/packages/apollos-rock-apollo-data-source/src/index.js
@@ -22,7 +22,14 @@ export default class RockApolloDataSource extends RESTDataSource {
 
   baseURL = ROCK.API_URL;
 
-  rockToken = ROCK.API_TOKEN;
+  userRequest = false;
+
+  get rockToken() {
+    if (!this.userRequest) {
+      return ROCK.API_TOKEN;
+    }
+    return null;
+  }
 
   nodeFetch = fetch;
 

--- a/scripts/watch.js
+++ b/scripts/watch.js
@@ -3,9 +3,15 @@ const chokidar = require('chokidar');
 
 console.log('Watching for changes');
 chokidar
-  .watch('packages/apollos-data-*/**', {
-    ignored: ['**/node_modules/**', '**/lib/**', '*.html', '*.snap'],
-  })
+  .watch(
+    [
+      'packages/apollos-data-*/**',
+      'packages/apollos-rock-apollo-data-source/**',
+    ],
+    {
+      ignored: ['**/node_modules/**', '**/lib/**', '*.html', '*.snap'],
+    }
+  )
   .on('change', (fullPath) => {
     const pkg = fullPath.split('/')[1].replace('apollos-', '@apollosproject/');
     exec(


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

User's were occasionally getting logged in as the Apollos user. The issue was that if a user's cookie was bad (potentially expired by rock?) the auth token was still being sent to Rock. The auth token belongs to the apollos user, so the apollos user was being sent as the current user. 

### What design trade-offs/decisions were made?

n/a

We still need a PR that logs users out if they receive a AuthenticationError on the front end. 

### How do I test this PR?

@conrad-vanl tested via deploying this to Heroku

### What automated tests did you write?

Updated existing snapshots. 

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Closes #876 
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
