### PR TITLE
Adds Check Against Short Content Summaries

### DIFF
--- a/packages/apollos-data-connector-rock/src/content-items/data-source.js
+++ b/packages/apollos-data-connector-rock/src/content-items/data-source.js
@@ -155,12 +155,20 @@ export default class ContentItem extends RockApolloDataSource {
     if (content.split(' ').length === 1) return '';
 
     const tokenizer = new natural.SentenceTokenizer();
-    return tokenizer.tokenize(
+    console.log(
       sanitizeHtmlNode(content, {
         allowedTags: [],
         allowedAttributes: [],
       })
-    )[0];
+    );
+    const tokens = tokenizer.tokenize(
+      sanitizeHtmlNode(content, {
+        allowedTags: [],
+        allowedAttributes: [],
+      })
+    );
+    // protects from starting with up to a three digit number and period
+    return tokens[0].length < 5 ? `${tokens[0]} ${tokens[1]}` : tokens[0];
   };
 
   getSermonFeed() {

--- a/packages/apollos-data-connector-rock/src/content-items/data-source.js
+++ b/packages/apollos-data-connector-rock/src/content-items/data-source.js
@@ -155,12 +155,6 @@ export default class ContentItem extends RockApolloDataSource {
     if (content.split(' ').length === 1) return '';
 
     const tokenizer = new natural.SentenceTokenizer();
-    console.log(
-      sanitizeHtmlNode(content, {
-        allowedTags: [],
-        allowedAttributes: [],
-      })
-    );
     const tokens = tokenizer.tokenize(
       sanitizeHtmlNode(content, {
         allowedTags: [],


### PR DESCRIPTION
## DESCRIPTION

<img width="1422" alt="Screen Shot 2019-07-23 at 2 50 42 PM" src="https://user-images.githubusercontent.com/2659478/61739138-d93f2700-ad59-11e9-9a0f-115d102b0dac.png">

### What does this PR do, or why is it needed?

Currently if a summary comes back starting with a number and a period, our natural language tokenizer splits on that number alone, this includes whatever follows that number.

### What design trade-offs/decisions were made?

None

### How do I test this PR?

Check the `userFeed` query or boot up the app, the "10 ways" content should now show a good summary.

### What automated tests did you write?

None

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Closes [#911]
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._