### PR TITLE
Updates the Test with Apollo Helper

### DIFF
--- a/packages/apolloschurchapp/src/utils/testUtils.js
+++ b/packages/apolloschurchapp/src/utils/testUtils.js
@@ -1,10 +1,34 @@
 /* eslint-disable import/prefer-default-export */
+import React from 'react';
 import renderer from 'react-test-renderer';
+import { MockedProvider } from 'react-apollo';
 import wait from 'waait';
 
-export const renderWithApolloData = async (component) => {
-  const tree = renderer.create(component);
-  await wait(1);
-  tree.update(component);
+export const renderWithApolloData = async (component, mocks = []) => {
+  /*
+   * mocks should be in the form:
+   *
+   *   mocks = [
+   *     {
+   *       request: {
+   *         query: GET_DOG_QUERY,
+   *         variables: {
+   *           name: 'Buck',
+   *         },
+   *       },
+   *       result: {
+   *         data: {
+   *           dog: { id: '1', name: 'Buck', breed: 'bulldog' },
+   *         },
+   *       },
+   *     },
+   *   ];
+   *
+   */
+
+  const tree = renderer.create(
+    <MockedProvider mocks={mocks}>{component}</MockedProvider>
+  );
+  await wait(0);
   return tree;
 };


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Updates the `renderWithApolloData` function to be more true to its name. It had nothing to do with Apollo before. And this also makes it a one-stop shop if I don't care about or need any other providers. Now usage is simply:

```
mocks = [{YOUR_MOCKS}]
tree = await renderWithApolloData(<FancyButton>, mocks)
expect(tree).toBeOrDoWhateverYouWant
```

There's just a lot of confusion around how to test connected components and this simplifies it I think. And as far as I can tell, the current `Providers` in the app package doesn't even contain `MockedProviders` so I don't think we're testing *any* connected components in the app.

### What design trade-offs/decisions were made?

### How do I test this PR?

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._