### PR TITLE
Standardizes FeaturedCard, HighlightCard, and ContentCard prop naming

### DIFF
--- a/packages/apollos-ui-kit/src/FeaturedCard/FeaturedCard.stories.js
+++ b/packages/apollos-ui-kit/src/FeaturedCard/FeaturedCard.stories.js
@@ -20,7 +20,7 @@ storiesOf('ui-kit/FeaturedCard', module)
       title={
         'Are you telling me that you built a time machine out of a DeLorean?'
       }
-      image={[
+      coverImage={[
         {
           uri: 'https://picsum.photos/800/1600/?random',
         },
@@ -37,7 +37,7 @@ storiesOf('ui-kit/FeaturedCard', module)
       title={
         'Are you telling me that you built a time machine out of a DeLorean?'
       }
-      image={[
+      coverImage={[
         {
           uri: 'https://picsum.photos/800/1600/?random',
         },
@@ -49,7 +49,7 @@ storiesOf('ui-kit/FeaturedCard', module)
       title={
         'Are you telling me that you built a time machine out of a DeLorean?'
       }
-      image={[
+      coverImage={[
         {
           uri: 'https://picsum.photos/800/1600/?random',
         },
@@ -63,7 +63,7 @@ storiesOf('ui-kit/FeaturedCard', module)
       title={
         'Are you telling me that you built a time machine out of a DeLorean?'
       }
-      image={[
+      coverImage={[
         {
           uri: 'https://picsum.photos/800/1600/?random',
         },
@@ -78,7 +78,7 @@ storiesOf('ui-kit/FeaturedCard', module)
       title={
         'Are you telling me that you built a time machine out of a DeLorean?'
       }
-      image={[
+      coverImage={[
         {
           uri: 'https://picsum.photos/800/1600/?random',
         },
@@ -91,7 +91,7 @@ storiesOf('ui-kit/FeaturedCard', module)
       title={
         'Are you telling me that you built a time machine out of a DeLorean?'
       }
-      image={[
+      coverImage={[
         {
           uri: 'https://picsum.photos/800/1600/?random',
         },
@@ -104,7 +104,7 @@ storiesOf('ui-kit/FeaturedCard', module)
       title={
         'Are you telling me that you built a time machine out of a DeLorean?'
       }
-      image={[
+      coverImage={[
         {
           uri: 'https://picsum.photos/800/1600/?random',
         },
@@ -117,7 +117,7 @@ storiesOf('ui-kit/FeaturedCard', module)
       title={
         'Are you telling me that you built a time machine out of a DeLorean?'
       }
-      image={[
+      coverImage={[
         {
           uri: 'https://picsum.photos/800/1600/?random',
         },
@@ -135,7 +135,7 @@ storiesOf('ui-kit/FeaturedCard', module)
       title={
         'Are you telling me that you built a time machine out of a DeLorean?'
       }
-      image={[
+      coverImage={[
         {
           uri: 'https://picsum.photos/800/1600/?random',
         },
@@ -148,7 +148,7 @@ storiesOf('ui-kit/FeaturedCard', module)
       title={
         'Are you telling me that you built a time machine out of a DeLorean?'
       }
-      image={[
+      coverImage={[
         {
           uri: 'https://picsum.photos/800/1600/?random',
         },
@@ -162,11 +162,12 @@ storiesOf('ui-kit/FeaturedCard', module)
         title={
           'Are you telling me that you built a time machine out of a DeLorean?'
         }
-        image={[
+        coverImage={[
           {
             uri: 'https://picsum.photos/800/1600/?random',
           },
         ]}
+        hasAction
         theme={{
           colors: {
             primary: 'salmon',
@@ -178,7 +179,7 @@ storiesOf('ui-kit/FeaturedCard', module)
         title={
           'Are you telling me that you built a time machine out of a DeLorean?'
         }
-        image={[
+        coverImage={[
           {
             uri: 'https://picsum.photos/800/1600/?random',
           },
@@ -191,13 +192,14 @@ storiesOf('ui-kit/FeaturedCard', module)
         title={
           'Are you telling me that you built a time machine out of a DeLorean?'
         }
-        image={[
+        coverImage={[
           {
             uri: 'https://picsum.photos/800/1600/?random',
           },
         ]}
         isLive
         isLiked
+        hasAction
         theme={{
           type: 'light',
           colors: {

--- a/packages/apollos-ui-kit/src/FeaturedCard/FeaturedCard.stories.js
+++ b/packages/apollos-ui-kit/src/FeaturedCard/FeaturedCard.stories.js
@@ -25,7 +25,7 @@ storiesOf('ui-kit/FeaturedCard', module)
           uri: 'https://picsum.photos/800/1600/?random',
         },
       ]}
-      description={
+      summary={
         'The way I see it, if you’re going to build a time machine into a car, why not do it with some style?'
       }
       hasAction
@@ -58,7 +58,7 @@ storiesOf('ui-kit/FeaturedCard', module)
       hasAction
     />
   ))
-  .add('description', () => (
+  .add('summary', () => (
     <FeaturedCard
       title={
         'Are you telling me that you built a time machine out of a DeLorean?'
@@ -68,7 +68,7 @@ storiesOf('ui-kit/FeaturedCard', module)
           uri: 'https://picsum.photos/800/1600/?random',
         },
       ]}
-      description={
+      summary={
         'The way I see it, if you’re going to build a time machine into a car, why not do it with some style?'
       }
     />
@@ -122,7 +122,7 @@ storiesOf('ui-kit/FeaturedCard', module)
           uri: 'https://picsum.photos/800/1600/?random',
         },
       ]}
-      description={
+      summary={
         'The way I see it, if you’re going to build a time machine into a car, why not do it with some style?'
       }
       hasAction
@@ -197,6 +197,9 @@ storiesOf('ui-kit/FeaturedCard', module)
             uri: 'https://picsum.photos/800/1600/?random',
           },
         ]}
+        summary={
+          'The way I see it, if you’re going to build a time machine into a car, why not do it with some style?'
+        }
         isLive
         isLiked
         hasAction

--- a/packages/apollos-ui-kit/src/FeaturedCard/FeaturedCard.tests.js
+++ b/packages/apollos-ui-kit/src/FeaturedCard/FeaturedCard.tests.js
@@ -14,7 +14,7 @@ describe('FeaturedCard', () => {
           title={
             'Are you telling me that you built a time machine out of a DeLorean?'
           }
-          image={[
+          coverImage={[
             {
               uri: 'https://picsum.photos/800/1600/?random',
             },
@@ -31,7 +31,7 @@ describe('FeaturedCard', () => {
           title={
             'Are you telling me that you built a time machine out of a DeLorean?'
           }
-          image={[
+          coverImage={[
             {
               uri: 'https://picsum.photos/800/1600/?random',
             },
@@ -50,7 +50,7 @@ describe('FeaturedCard', () => {
           title={
             'Are you telling me that you built a time machine out of a DeLorean?'
           }
-          image={[
+          coverImage={[
             {
               uri: 'https://picsum.photos/800/1600/?random',
             },
@@ -70,7 +70,7 @@ describe('FeaturedCard', () => {
           title={
             'Are you telling me that you built a time machine out of a DeLorean?'
           }
-          image={[
+          coverImage={[
             {
               uri: 'https://picsum.photos/800/1600/?random',
             },
@@ -88,7 +88,7 @@ describe('FeaturedCard', () => {
           title={
             'Are you telling me that you built a time machine out of a DeLorean?'
           }
-          image={[
+          coverImage={[
             {
               uri: 'https://picsum.photos/800/1600/?random',
             },
@@ -106,7 +106,7 @@ describe('FeaturedCard', () => {
           title={
             'Are you telling me that you built a time machine out of a DeLorean?'
           }
-          image={[
+          coverImage={[
             {
               uri: 'https://picsum.photos/800/1600/?random',
             },
@@ -124,7 +124,7 @@ describe('FeaturedCard', () => {
           title={
             'Are you telling me that you built a time machine out of a DeLorean?'
           }
-          image={[
+          coverImage={[
             {
               uri: 'https://picsum.photos/800/1600/?random',
             },
@@ -147,7 +147,7 @@ describe('FeaturedCard', () => {
           title={
             'Are you telling me that you built a time machine out of a DeLorean?'
           }
-          image={[
+          coverImage={[
             {
               uri: 'https://picsum.photos/800/1600/?random',
             },
@@ -165,7 +165,7 @@ describe('FeaturedCard', () => {
           title={
             'Are you telling me that you built a time machine out of a DeLorean?'
           }
-          image={[
+          coverImage={[
             {
               uri: 'https://picsum.photos/800/1600/?random',
             },
@@ -183,7 +183,7 @@ describe('FeaturedCard', () => {
           title={
             'Are you telling me that you built a time machine out of a DeLorean?'
           }
-          image={[
+          coverImage={[
             {
               uri: 'https://picsum.photos/800/1600/?random',
             },

--- a/packages/apollos-ui-kit/src/FeaturedCard/FeaturedCard.tests.js
+++ b/packages/apollos-ui-kit/src/FeaturedCard/FeaturedCard.tests.js
@@ -43,7 +43,7 @@ describe('FeaturedCard', () => {
     );
     expect(tree).toMatchSnapshot();
   });
-  it('should render with a description', () => {
+  it('should render with a summary', () => {
     const tree = renderer.create(
       <Providers>
         <FeaturedCard
@@ -55,7 +55,7 @@ describe('FeaturedCard', () => {
               uri: 'https://picsum.photos/800/1600/?random',
             },
           ]}
-          description={
+          summary={
             'The way I see it, if you’re going to build a time machine into a car, why not do it with some style?'
           }
         />
@@ -129,7 +129,7 @@ describe('FeaturedCard', () => {
               uri: 'https://picsum.photos/800/1600/?random',
             },
           ]}
-          description={
+          summary={
             'The way I see it, if you’re going to build a time machine into a car, why not do it with some style?'
           }
           hasAction

--- a/packages/apollos-ui-kit/src/FeaturedCard/__snapshots__/FeaturedCard.tests.js.snap
+++ b/packages/apollos-ui-kit/src/FeaturedCard/__snapshots__/FeaturedCard.tests.js.snap
@@ -152,7 +152,7 @@ exports[`FeaturedCard should render 1`] = `
           }
         >
           <View
-            hasDescription={false}
+            hasSummary={false}
             style={
               Object {
                 "alignItems": "flex-end",
@@ -497,7 +497,7 @@ exports[`FeaturedCard should render a loading state with isLoading 1`] = `
             }
           />
           <View
-            hasDescription={true}
+            hasSummary={true}
             style={
               Object {
                 "alignItems": "center",
@@ -717,7 +717,7 @@ exports[`FeaturedCard should render with a custom actionIcon 1`] = `
           }
         >
           <View
-            hasDescription={false}
+            hasSummary={false}
             style={
               Object {
                 "alignItems": "flex-end",
@@ -1149,7 +1149,7 @@ exports[`FeaturedCard should render with a custom theme 1`] = `
           }
         >
           <View
-            hasDescription={false}
+            hasSummary={false}
             style={
               Object {
                 "alignItems": "flex-end",
@@ -1314,7 +1314,7 @@ exports[`FeaturedCard should render with a custom theme 1`] = `
 </RCTSafeAreaView>
 `;
 
-exports[`FeaturedCard should render with a description 1`] = `
+exports[`FeaturedCard should render with a summary 1`] = `
 <RCTSafeAreaView
   emulateUnlessSupported={true}
   onLayout={[Function]}
@@ -1479,7 +1479,7 @@ exports[`FeaturedCard should render with a description 1`] = `
             Are you telling me that you built a time machine out of a DeLorean?
           </Text>
           <View
-            hasDescription={true}
+            hasSummary={true}
             style={
               Object {
                 "alignItems": "center",
@@ -1852,7 +1852,7 @@ exports[`FeaturedCard should render with custom LabelComponent 1`] = `
             </Text>
           </View>
           <View
-            hasDescription={false}
+            hasSummary={false}
             style={
               Object {
                 "alignItems": "flex-end",
@@ -2223,7 +2223,7 @@ exports[`FeaturedCard should render with custom labelText 1`] = `
             </Text>
           </View>
           <View
-            hasDescription={false}
+            hasSummary={false}
             style={
               Object {
                 "alignItems": "flex-end",
@@ -2540,7 +2540,7 @@ exports[`FeaturedCard should should render as isLiked 1`] = `
           }
         >
           <View
-            hasDescription={false}
+            hasSummary={false}
             style={
               Object {
                 "alignItems": "flex-end",
@@ -3014,7 +3014,7 @@ exports[`FeaturedCard should should render as isLive 1`] = `
             </Text>
           </View>
           <View
-            hasDescription={false}
+            hasSummary={false}
             style={
               Object {
                 "alignItems": "flex-end",
@@ -3331,7 +3331,7 @@ exports[`FeaturedCard should should render with an action "button" 1`] = `
           }
         >
           <View
-            hasDescription={false}
+            hasSummary={false}
             style={
               Object {
                 "alignItems": "flex-end",

--- a/packages/apollos-ui-kit/src/FeaturedCard/index.js
+++ b/packages/apollos-ui-kit/src/FeaturedCard/index.js
@@ -42,12 +42,12 @@ const Content = styled(({ theme }) => ({
   paddingBottom: theme.sizing.baseUnit * 2, // TODO: refactor CardContent to have this be the default
 }))(CardContent);
 
-const ActionLayout = styled(({ theme, hasDescription }) => ({
+const ActionLayout = styled(({ theme, hasSummary }) => ({
   flexDirection: 'row',
-  /* - `center` works in all situations including 1 line descriptions
-   * - `flex-end` is needed only for when we have no description
+  /* - `center` works in all situations including 1 line summaries
+   * - `flex-end` is needed only for when we have no summary
    */
-  alignItems: hasDescription ? 'center' : 'flex-end',
+  alignItems: hasSummary ? 'center' : 'flex-end',
   paddingTop: theme.sizing.baseUnit,
 }))(View);
 
@@ -61,7 +61,7 @@ const ActionIcon = withTheme(({ theme }) => ({
 }))(Icon);
 
 const Label = withTheme(
-  ({ customTheme, hasDescription, isLive, labelText, theme }) => ({
+  ({ customTheme, hasSummary, isLive, labelText, theme }) => ({
     ...(isLive
       ? {
           title: labelText || 'Live',
@@ -75,12 +75,12 @@ const Label = withTheme(
           type: 'overlay',
         }),
     style: {
-      ...(hasDescription ? { marginBottom: theme.sizing.baseUnit } : {}),
+      ...(hasSummary ? { marginBottom: theme.sizing.baseUnit } : {}),
     },
   })
 )(CardLabel);
 
-const renderLabel = (description, LabelComponent, labelText, isLive, theme) => {
+const renderLabel = (summary, LabelComponent, labelText, isLive, theme) => {
   let ComponentToRender = null;
 
   if (LabelComponent) {
@@ -89,7 +89,7 @@ const renderLabel = (description, LabelComponent, labelText, isLive, theme) => {
     ComponentToRender = (
       <Label
         customTheme={theme}
-        hasDescription={description}
+        hasSummary={summary}
         isLive={isLive}
         labelText={labelText}
       />
@@ -100,7 +100,7 @@ const renderLabel = (description, LabelComponent, labelText, isLive, theme) => {
 };
 
 const renderOnlyTitle = (title, actionIcon, hasAction) => (
-  <ActionLayout hasDescription={false}>
+  <ActionLayout hasSummary={false}>
     <FlexedActionLayoutText>
       <H2 numberOfLines={4}>{title}</H2>
     </FlexedActionLayoutText>
@@ -108,12 +108,12 @@ const renderOnlyTitle = (title, actionIcon, hasAction) => (
   </ActionLayout>
 );
 
-const renderWithDescription = (title, actionIcon, description, hasAction) => (
+const renderWithSummary = (title, actionIcon, summary, hasAction) => (
   <>
     <H2 numberOfLines={3}>{title}</H2>
-    <ActionLayout hasDescription>
+    <ActionLayout hasSummary>
       <FlexedActionLayoutText>
-        <BodyText numberOfLines={2}>{description}</BodyText>
+        <BodyText numberOfLines={2}>{summary}</BodyText>
       </FlexedActionLayoutText>
       {hasAction ? <ActionIcon name={actionIcon} /> : null}
     </ActionLayout>
@@ -125,7 +125,7 @@ const FeaturedCard = withIsLoading(
     coverImage,
     title,
     actionIcon,
-    description,
+    summary,
     hasAction,
     isLiked,
     isLive,
@@ -144,9 +144,9 @@ const FeaturedCard = withIsLoading(
         <Image source={coverImage} overlayType={'featured'} />
 
         <Content>
-          {renderLabel(description, LabelComponent, labelText, isLive, theme)}
-          {description
-            ? renderWithDescription(title, actionIcon, description, hasAction)
+          {renderLabel(summary, LabelComponent, labelText, isLive, theme)}
+          {summary
+            ? renderWithSummary(title, actionIcon, summary, hasAction)
             : renderOnlyTitle(title, actionIcon, hasAction)}
         </Content>
         <LikeIconPositioning>
@@ -164,7 +164,7 @@ FeaturedCard.propTypes = {
   ]).isRequired,
   title: PropTypes.string.isRequired,
   actionIcon: PropTypes.string,
-  description: PropTypes.string,
+  summary: PropTypes.string,
   hasAction: PropTypes.bool,
   isLiked: PropTypes.bool,
   isLive: PropTypes.bool,

--- a/packages/apollos-ui-kit/src/FeaturedCard/index.js
+++ b/packages/apollos-ui-kit/src/FeaturedCard/index.js
@@ -125,13 +125,13 @@ const FeaturedCard = withIsLoading(
     coverImage,
     title,
     actionIcon,
-    summary,
     hasAction,
     isLiked,
     isLive,
     isLoading,
     LabelComponent,
     labelText,
+    summary,
     theme,
   }) => (
     <ThemeMixin
@@ -164,12 +164,12 @@ FeaturedCard.propTypes = {
   ]).isRequired,
   title: PropTypes.string.isRequired,
   actionIcon: PropTypes.string,
-  summary: PropTypes.string,
   hasAction: PropTypes.bool,
   isLiked: PropTypes.bool,
   isLive: PropTypes.bool,
   LabelComponent: PropTypes.element,
   labelText: PropTypes.string,
+  summary: PropTypes.string,
   theme: PropTypes.shape({
     type: PropTypes.string,
     colors: PropTypes.shape({}),

--- a/packages/apollos-ui-kit/src/FeaturedCard/index.js
+++ b/packages/apollos-ui-kit/src/FeaturedCard/index.js
@@ -122,7 +122,7 @@ const renderWithDescription = (title, actionIcon, description, hasAction) => (
 
 const FeaturedCard = withIsLoading(
   ({
-    image,
+    coverImage,
     title,
     actionIcon,
     description,
@@ -141,7 +141,7 @@ const FeaturedCard = withIsLoading(
       }}
     >
       <StyledCard isLoading={isLoading}>
-        <Image source={image} overlayType={'featured'} />
+        <Image source={coverImage} overlayType={'featured'} />
 
         <Content>
           {renderLabel(description, LabelComponent, labelText, isLive, theme)}
@@ -158,7 +158,7 @@ const FeaturedCard = withIsLoading(
 );
 
 FeaturedCard.propTypes = {
-  image: PropTypes.oneOfType([
+  coverImage: PropTypes.oneOfType([
     PropTypes.arrayOf(ImageSourceType),
     ImageSourceType,
   ]).isRequired,

--- a/packages/apollos-ui-kit/src/HighlightCard/HighlightCard.stories.js
+++ b/packages/apollos-ui-kit/src/HighlightCard/HighlightCard.stories.js
@@ -26,7 +26,7 @@ storiesOf('ui-kit/HighlightCard', module)
             uri: 'https://picsum.photos/800/1600/?random',
           },
         ]}
-        description={
+        summary={
           'The way I see it, if you’re going to build a time machine into a car, why not do it with some style?'
         }
         hasAction
@@ -41,7 +41,7 @@ storiesOf('ui-kit/HighlightCard', module)
             uri: 'https://picsum.photos/1600/800/?random',
           },
         ]}
-        description={
+        summary={
           'The way I see it, if you’re going to build a time machine into a car, why not do it with some style?'
         }
         hasAction
@@ -56,7 +56,7 @@ storiesOf('ui-kit/HighlightCard', module)
             uri: 'https://picsum.photos/800/800/?random',
           },
         ]}
-        description={
+        summary={
           'The way I see it, if you’re going to build a time machine into a car, why not do it with some style?'
         }
         hasAction
@@ -90,7 +90,7 @@ storiesOf('ui-kit/HighlightCard', module)
       hasAction
     />
   ))
-  .add('description', () => (
+  .add('summary', () => (
     <HighlightCard
       title={
         'Are you telling me that you built a time machine out of a DeLorean?'
@@ -100,7 +100,7 @@ storiesOf('ui-kit/HighlightCard', module)
           uri: 'https://picsum.photos/800/1600/?random',
         },
       ]}
-      description={
+      summary={
         'The way I see it, if you’re going to build a time machine into a car, why not do it with some style?'
       }
     />
@@ -128,7 +128,7 @@ storiesOf('ui-kit/HighlightCard', module)
           uri: 'https://picsum.photos/800/1600/?random',
         },
       ]}
-      description={
+      summary={
         'The way I see it, if you’re going to build a time machine into a car, why not do it with some style?'
       }
       hasAction
@@ -206,6 +206,7 @@ storiesOf('ui-kit/HighlightCard', module)
           },
         ]}
         labelText={'Quote'}
+        hasAction
         isLiked
         theme={{
           type: 'light',

--- a/packages/apollos-ui-kit/src/HighlightCard/HighlightCard.stories.js
+++ b/packages/apollos-ui-kit/src/HighlightCard/HighlightCard.stories.js
@@ -21,7 +21,7 @@ storiesOf('ui-kit/HighlightCard', module)
         title={
           'Are you telling me that you built a time machine out of a DeLorean?'
         }
-        image={[
+        coverImage={[
           {
             uri: 'https://picsum.photos/800/1600/?random',
           },
@@ -36,7 +36,7 @@ storiesOf('ui-kit/HighlightCard', module)
         title={
           'Are you telling me that you built a time machine out of a DeLorean?'
         }
-        image={[
+        coverImage={[
           {
             uri: 'https://picsum.photos/1600/800/?random',
           },
@@ -51,7 +51,7 @@ storiesOf('ui-kit/HighlightCard', module)
         title={
           'Are you telling me that you built a time machine out of a DeLorean?'
         }
-        image={[
+        coverImage={[
           {
             uri: 'https://picsum.photos/800/800/?random',
           },
@@ -69,7 +69,7 @@ storiesOf('ui-kit/HighlightCard', module)
       title={
         'Are you telling me that you built a time machine out of a DeLorean?'
       }
-      image={[
+      coverImage={[
         {
           uri: 'https://picsum.photos/800/1600/?random',
         },
@@ -81,7 +81,7 @@ storiesOf('ui-kit/HighlightCard', module)
       title={
         'Are you telling me that you built a time machine out of a DeLorean?'
       }
-      image={[
+      coverImage={[
         {
           uri: 'https://picsum.photos/800/1600/?random',
         },
@@ -95,7 +95,7 @@ storiesOf('ui-kit/HighlightCard', module)
       title={
         'Are you telling me that you built a time machine out of a DeLorean?'
       }
-      image={[
+      coverImage={[
         {
           uri: 'https://picsum.photos/800/1600/?random',
         },
@@ -110,7 +110,7 @@ storiesOf('ui-kit/HighlightCard', module)
       title={
         'Are you telling me that you built a time machine out of a DeLorean?'
       }
-      image={[
+      coverImage={[
         {
           uri: 'https://picsum.photos/800/1600/?random',
         },
@@ -123,7 +123,7 @@ storiesOf('ui-kit/HighlightCard', module)
       title={
         'Are you telling me that you built a time machine out of a DeLorean?'
       }
-      image={[
+      coverImage={[
         {
           uri: 'https://picsum.photos/800/1600/?random',
         },
@@ -141,7 +141,7 @@ storiesOf('ui-kit/HighlightCard', module)
       title={
         'Are you telling me that you built a time machine out of a DeLorean?'
       }
-      image={[
+      coverImage={[
         {
           uri: 'https://picsum.photos/800/1600/?random',
         },
@@ -154,7 +154,7 @@ storiesOf('ui-kit/HighlightCard', module)
       title={
         'Are you telling me that you built a time machine out of a DeLorean?'
       }
-      image={[
+      coverImage={[
         {
           uri: 'https://picsum.photos/800/1600/?random',
         },
@@ -167,7 +167,7 @@ storiesOf('ui-kit/HighlightCard', module)
       title={
         'Are you telling me that you built a time machine out of a DeLorean?'
       }
-      image={[
+      coverImage={[
         {
           uri: 'https://picsum.photos/800/1600/?random',
         },
@@ -185,7 +185,7 @@ storiesOf('ui-kit/HighlightCard', module)
         title={
           'Are you telling me that you built a time machine out of a DeLorean?'
         }
-        image={[
+        coverImage={[
           {
             uri: 'https://picsum.photos/800/1600/?random',
           },
@@ -200,7 +200,7 @@ storiesOf('ui-kit/HighlightCard', module)
         title={
           'Are you telling me that you built a time machine out of a DeLorean?'
         }
-        image={[
+        coverImage={[
           {
             uri: 'https://picsum.photos/800/1600/?random',
           },

--- a/packages/apollos-ui-kit/src/HighlightCard/HighlightCard.tests.js
+++ b/packages/apollos-ui-kit/src/HighlightCard/HighlightCard.tests.js
@@ -60,7 +60,7 @@ describe('HighlightCard', () => {
     );
     expect(tree).toMatchSnapshot();
   });
-  it('should render with a description', () => {
+  it('should render with a summary', () => {
     const tree = renderer.create(
       <Providers>
         <HighlightCard
@@ -72,7 +72,7 @@ describe('HighlightCard', () => {
               uri: 'https://picsum.photos/800/1600/?random',
             },
           ]}
-          description={
+          summary={
             'The way I see it, if you’re going to build a time machine into a car, why not do it with some style?'
           }
         />
@@ -146,7 +146,7 @@ describe('HighlightCard', () => {
               uri: 'https://picsum.photos/800/1600/?random',
             },
           ]}
-          description={
+          summary={
             'The way I see it, if you’re going to build a time machine into a car, why not do it with some style?'
           }
           hasAction

--- a/packages/apollos-ui-kit/src/HighlightCard/HighlightCard.tests.js
+++ b/packages/apollos-ui-kit/src/HighlightCard/HighlightCard.tests.js
@@ -14,7 +14,7 @@ describe('HighlightCard', () => {
           title={
             'Are you telling me that you built a time machine out of a DeLorean?'
           }
-          image={[
+          coverImage={[
             {
               uri: 'https://picsum.photos/800/1600/?random',
             },
@@ -31,7 +31,7 @@ describe('HighlightCard', () => {
           title={
             'Are you telling me that you built a time machine out of a DeLorean?'
           }
-          image={[
+          coverImage={[
             {
               uri: 'https://picsum.photos/1600/800/?random',
             },
@@ -48,7 +48,7 @@ describe('HighlightCard', () => {
           title={
             'Are you telling me that you built a time machine out of a DeLorean?'
           }
-          image={[
+          coverImage={[
             {
               uri: 'https://picsum.photos/800/1600/?random',
             },
@@ -67,7 +67,7 @@ describe('HighlightCard', () => {
           title={
             'Are you telling me that you built a time machine out of a DeLorean?'
           }
-          image={[
+          coverImage={[
             {
               uri: 'https://picsum.photos/800/1600/?random',
             },
@@ -87,7 +87,7 @@ describe('HighlightCard', () => {
           title={
             'Are you telling me that you built a time machine out of a DeLorean?'
           }
-          image={[
+          coverImage={[
             {
               uri: 'https://picsum.photos/800/1600/?random',
             },
@@ -105,7 +105,7 @@ describe('HighlightCard', () => {
           title={
             'Are you telling me that you built a time machine out of a DeLorean?'
           }
-          image={[
+          coverImage={[
             {
               uri: 'https://picsum.photos/800/1600/?random',
             },
@@ -123,7 +123,7 @@ describe('HighlightCard', () => {
           title={
             'Are you telling me that you built a time machine out of a DeLorean?'
           }
-          image={[
+          coverImage={[
             {
               uri: 'https://picsum.photos/800/1600/?random',
             },
@@ -141,7 +141,7 @@ describe('HighlightCard', () => {
           title={
             'Are you telling me that you built a time machine out of a DeLorean?'
           }
-          image={[
+          coverImage={[
             {
               uri: 'https://picsum.photos/800/1600/?random',
             },
@@ -164,7 +164,7 @@ describe('HighlightCard', () => {
           title={
             'Are you telling me that you built a time machine out of a DeLorean?'
           }
-          image={[
+          coverImage={[
             {
               uri: 'https://picsum.photos/800/1600/?random',
             },
@@ -182,7 +182,7 @@ describe('HighlightCard', () => {
           title={
             'Are you telling me that you built a time machine out of a DeLorean?'
           }
-          image={[
+          coverImage={[
             {
               uri: 'https://picsum.photos/800/1600/?random',
             },
@@ -200,7 +200,7 @@ describe('HighlightCard', () => {
           title={
             'Are you telling me that you built a time machine out of a DeLorean?'
           }
-          image={[
+          coverImage={[
             {
               uri: 'https://picsum.photos/800/1600/?random',
             },

--- a/packages/apollos-ui-kit/src/HighlightCard/__snapshots__/HighlightCard.tests.js.snap
+++ b/packages/apollos-ui-kit/src/HighlightCard/__snapshots__/HighlightCard.tests.js.snap
@@ -168,7 +168,7 @@ exports[`HighlightCard should render a loading state with isLoading 1`] = `
             }
           />
           <View
-            hasDescription={true}
+            hasSummary={true}
             style={
               Object {
                 "alignItems": "center",
@@ -390,7 +390,7 @@ exports[`HighlightCard should render in a "tall" aspect ratio (maxAspectRatio) 1
           }
         >
           <View
-            hasDescription={false}
+            hasSummary={false}
             style={
               Object {
                 "alignItems": "flex-end",
@@ -709,7 +709,7 @@ exports[`HighlightCard should render in a "wide" aspect ratio 1`] = `
           }
         >
           <View
-            hasDescription={false}
+            hasSummary={false}
             style={
               Object {
                 "alignItems": "flex-end",
@@ -1028,7 +1028,7 @@ exports[`HighlightCard should render with a custom actionIcon 1`] = `
           }
         >
           <View
-            hasDescription={false}
+            hasSummary={false}
             style={
               Object {
                 "alignItems": "flex-end",
@@ -1469,7 +1469,7 @@ exports[`HighlightCard should render with a custom theme 1`] = `
           }
         >
           <View
-            hasDescription={false}
+            hasSummary={false}
             style={
               Object {
                 "alignItems": "flex-end",
@@ -1634,7 +1634,7 @@ exports[`HighlightCard should render with a custom theme 1`] = `
 </RCTSafeAreaView>
 `;
 
-exports[`HighlightCard should render with a description 1`] = `
+exports[`HighlightCard should render with a summary 1`] = `
 <RCTSafeAreaView
   emulateUnlessSupported={true}
   onLayout={[Function]}
@@ -1801,7 +1801,7 @@ exports[`HighlightCard should render with a description 1`] = `
             Are you telling me that you built a time machine out of a DeLorean?
           </Text>
           <View
-            hasDescription={true}
+            hasSummary={true}
             style={
               Object {
                 "alignItems": "center",
@@ -2176,7 +2176,7 @@ exports[`HighlightCard should render with custom LabelComponent 1`] = `
             </Text>
           </View>
           <View
-            hasDescription={false}
+            hasSummary={false}
             style={
               Object {
                 "alignItems": "flex-end",
@@ -2549,7 +2549,7 @@ exports[`HighlightCard should render with custom labelText 1`] = `
             </Text>
           </View>
           <View
-            hasDescription={false}
+            hasSummary={false}
             style={
               Object {
                 "alignItems": "flex-end",
@@ -2868,7 +2868,7 @@ exports[`HighlightCard should should render as isLiked 1`] = `
           }
         >
           <View
-            hasDescription={false}
+            hasSummary={false}
             style={
               Object {
                 "alignItems": "flex-end",
@@ -3188,7 +3188,7 @@ exports[`HighlightCard should should render as isLive 1`] = `
           }
         >
           <View
-            hasDescription={false}
+            hasSummary={false}
             style={
               Object {
                 "alignItems": "flex-end",
@@ -3507,7 +3507,7 @@ exports[`HighlightCard should should render with an action "button" 1`] = `
           }
         >
           <View
-            hasDescription={false}
+            hasSummary={false}
             style={
               Object {
                 "alignItems": "flex-end",

--- a/packages/apollos-ui-kit/src/HighlightCard/__snapshots__/HighlightCard.tests.js.snap
+++ b/packages/apollos-ui-kit/src/HighlightCard/__snapshots__/HighlightCard.tests.js.snap
@@ -3607,7 +3607,53 @@ exports[`HighlightCard should should render with an action "button" 1`] = `
                 y={0}
               >
                 <RNSVGPath
-                  d="M24 0a24 24 0 1 1 0 48 24 24 0 0 1 0-48zm9.2 25.5c.5-.4.8-.9.8-1.4 0-.7-.3-1.2-.8-1.5l-12-8.3c-.5-.2-1.1-.2-1.7 0-.5.3-.8.9-.8 1.5v16.4a1.7 1.7 0 0 0 1.7 1.7c.3 0 .6 0 1-.2l11.8-8.2z"
+                  d="M24 0a24 24 0 1 0 0 48 24 24 0 0 0 0-48z"
+                  fill={
+                    Array [
+                      0,
+                      4294506484,
+                    ]
+                  }
+                  fillOpacity={0.1}
+                  fillRule={1}
+                  matrix={
+                    Array [
+                      1,
+                      0,
+                      0,
+                      1,
+                      0,
+                      0,
+                    ]
+                  }
+                  opacity={1}
+                  originX={0}
+                  originY={0}
+                  propList={
+                    Array [
+                      "fill",
+                      "fillOpacity",
+                    ]
+                  }
+                  rotation={0}
+                  scaleX={1}
+                  scaleY={1}
+                  skewX={0}
+                  skewY={0}
+                  stroke={null}
+                  strokeDasharray={null}
+                  strokeDashoffset={null}
+                  strokeLinecap={0}
+                  strokeLinejoin={0}
+                  strokeMiterlimit={4}
+                  strokeOpacity={1}
+                  strokeWidth={1}
+                  vectorEffect={0}
+                  x={0}
+                  y={0}
+                />
+                <RNSVGPath
+                  d="M20 15.3c0-1.3.9-1.7 2-1l11 8c1.1.8 1.1 2 0 2.8l-11 8.4c-1.1.9-2 .5-2-.8V15.3z"
                   fill={
                     Array [
                       0,

--- a/packages/apollos-ui-kit/src/HighlightCard/index.js
+++ b/packages/apollos-ui-kit/src/HighlightCard/index.js
@@ -121,12 +121,12 @@ const HighlightCard = withIsLoading(
     coverImage,
     title,
     actionIcon,
-    summary,
     hasAction,
     isLiked,
     isLoading,
     LabelComponent,
     labelText,
+    summary,
     theme,
   }) => (
     <ThemeMixin
@@ -162,11 +162,11 @@ HighlightCard.propTypes = {
   ]).isRequired,
   title: PropTypes.string.isRequired,
   actionIcon: PropTypes.string,
-  summary: PropTypes.string,
   hasAction: PropTypes.bool,
   isLiked: PropTypes.bool,
   LabelComponent: PropTypes.element,
   labelText: PropTypes.string,
+  summary: PropTypes.string,
   theme: PropTypes.shape({
     type: PropTypes.string,
     colors: PropTypes.shape({}),

--- a/packages/apollos-ui-kit/src/HighlightCard/index.js
+++ b/packages/apollos-ui-kit/src/HighlightCard/index.js
@@ -17,11 +17,14 @@ const StyledCard = withTheme(({ theme }) => ({
 }))(Card);
 
 // We have to position `LikeIcon` in a `View` rather than `LikeIcon` directly so `LikeIcon`'s loading state is positioned correctly 💥
-const LikeIconPositioning = styled(({ theme }) => ({
-  position: 'absolute',
-  top: theme.sizing.baseUnit * 1.5,
-  right: theme.sizing.baseUnit * 1.5,
-}))(View);
+const LikeIconPositioning = styled(
+  ({ theme }) => ({
+    position: 'absolute',
+    top: theme.sizing.baseUnit * 1.5,
+    right: theme.sizing.baseUnit * 1.5,
+  }),
+  'ui-kit.HighlightCard.LikeIconPositioning'
+)(View);
 
 const LikeIcon = withTheme(({ theme, isLiked }) => ({
   name: isLiked ? 'like-solid' : 'like',
@@ -36,23 +39,29 @@ const Image = withTheme(({ theme, customTheme }) => ({
   overlayColor: get(customTheme, 'colors.primary', theme.colors.black),
 }))(CardImage);
 
-const Content = styled(({ theme }) => ({
-  position: 'absolute',
-  bottom: 0,
-  width: '100%',
-  alignItems: 'flex-start', // needed to make `Label` display as an "inline" element
-  paddingHorizontal: theme.sizing.baseUnit * 1.5, // TODO: refactor CardContent to have this be the default
-  paddingBottom: theme.sizing.baseUnit * 2, // TODO: refactor CardContent to have this be the default
-}))(CardContent);
+const Content = styled(
+  ({ theme }) => ({
+    position: 'absolute',
+    bottom: 0,
+    width: '100%',
+    alignItems: 'flex-start', // needed to make `Label` display as an "inline" element
+    paddingHorizontal: theme.sizing.baseUnit * 1.5, // TODO: refactor CardContent to have this be the default
+    paddingBottom: theme.sizing.baseUnit * 2, // TODO: refactor CardContent to have this be the default
+  }),
+  'ui-kit.HighlightCard.Content'
+)(CardContent);
 
-const ActionLayout = styled(({ theme, hasDescription }) => ({
-  flexDirection: 'row',
-  /* - `center` works in all situations including 1 line descriptions
-   * - `flex-end` is needed only for when we have no description
-   */
-  alignItems: hasDescription ? 'center' : 'flex-end',
-  paddingTop: theme.sizing.baseUnit,
-}))(View);
+const ActionLayout = styled(
+  ({ theme, hasSummary }) => ({
+    flexDirection: 'row',
+    /* - `center` works in all situations including 1 line summarys
+     * - `flex-end` is needed only for when we have no summary
+     */
+    alignItems: hasSummary ? 'center' : 'flex-end',
+    paddingTop: theme.sizing.baseUnit,
+  }),
+  'ui-kit.HighlightCard.ActionLayout'
+)(View);
 
 const FlexedActionLayoutText = styled(({ theme }) => ({
   marginRight: theme.sizing.baseUnit, // spaces out text from `ActionIcon`. This has to live here for ActionIcon's loading state
@@ -63,29 +72,23 @@ const ActionIcon = withTheme(({ theme }) => ({
   size: theme.sizing.baseUnit * 3,
 }))(Icon);
 
-const Label = withTheme(
-  ({ customTheme, hasDescription, labelText, theme }) => ({
-    title: labelText,
-    theme: { colors: get(customTheme, 'colors', {}) },
-    type: 'overlay',
-    style: {
-      ...(hasDescription ? { marginBottom: theme.sizing.baseUnit } : {}),
-    },
-  })
-)(CardLabel);
+const Label = withTheme(({ customTheme, hasSummary, labelText, theme }) => ({
+  title: labelText,
+  theme: { colors: get(customTheme, 'colors', {}) },
+  type: 'overlay',
+  style: {
+    ...(hasSummary ? { marginBottom: theme.sizing.baseUnit } : {}),
+  },
+}))(CardLabel);
 
-const renderLabel = (description, LabelComponent, labelText, theme) => {
+const renderLabel = (summary, LabelComponent, labelText, theme) => {
   let ComponentToRender = null;
 
   if (LabelComponent) {
     ComponentToRender = LabelComponent;
   } else if (labelText) {
     ComponentToRender = (
-      <Label
-        customTheme={theme}
-        hasDescription={description}
-        labelText={labelText}
-      />
+      <Label customTheme={theme} hasSummary={summary} labelText={labelText} />
     );
   }
 
@@ -93,7 +96,7 @@ const renderLabel = (description, LabelComponent, labelText, theme) => {
 };
 
 const renderOnlyTitle = (title, actionIcon, hasAction) => (
-  <ActionLayout hasDescription={false}>
+  <ActionLayout hasSummary={false}>
     <FlexedActionLayoutText>
       <H3 numberOfLines={4}>{title}</H3>
     </FlexedActionLayoutText>
@@ -101,12 +104,12 @@ const renderOnlyTitle = (title, actionIcon, hasAction) => (
   </ActionLayout>
 );
 
-const renderWithDescription = (title, actionIcon, description, hasAction) => (
+const renderWithSummary = (title, actionIcon, summary, hasAction) => (
   <>
     <H3 numberOfLines={3}>{title}</H3>
-    <ActionLayout hasDescription>
+    <ActionLayout hasSummary>
       <FlexedActionLayoutText>
-        <BodyText numberOfLines={2}>{description}</BodyText>
+        <BodyText numberOfLines={2}>{summary}</BodyText>
       </FlexedActionLayoutText>
       {hasAction ? <ActionIcon name={actionIcon} /> : null}
     </ActionLayout>
@@ -118,7 +121,7 @@ const HighlightCard = withIsLoading(
     image,
     title,
     actionIcon,
-    description,
+    summary,
     hasAction,
     isLiked,
     isLoading,
@@ -139,9 +142,9 @@ const HighlightCard = withIsLoading(
           source={image}
         />
         <Content>
-          {renderLabel(description, LabelComponent, labelText, theme)}
-          {description
-            ? renderWithDescription(title, actionIcon, description, hasAction)
+          {renderLabel(summary, LabelComponent, labelText, theme)}
+          {summary
+            ? renderWithSummary(title, actionIcon, summary, hasAction)
             : renderOnlyTitle(title, actionIcon, hasAction)}
         </Content>
         <LikeIconPositioning>
@@ -159,7 +162,7 @@ HighlightCard.propTypes = {
   ]).isRequired,
   title: PropTypes.string.isRequired,
   actionIcon: PropTypes.string,
-  description: PropTypes.string,
+  summary: PropTypes.string,
   hasAction: PropTypes.bool,
   isLiked: PropTypes.bool,
   LabelComponent: PropTypes.element,

--- a/packages/apollos-ui-kit/src/HighlightCard/index.js
+++ b/packages/apollos-ui-kit/src/HighlightCard/index.js
@@ -174,7 +174,7 @@ HighlightCard.propTypes = {
 };
 
 HighlightCard.defaultProps = {
-  actionIcon: 'play-solid',
+  actionIcon: 'play-opaque',
 };
 
 export default HighlightCard;

--- a/packages/apollos-ui-kit/src/HighlightCard/index.js
+++ b/packages/apollos-ui-kit/src/HighlightCard/index.js
@@ -54,7 +54,7 @@ const Content = styled(
 const ActionLayout = styled(
   ({ theme, hasSummary }) => ({
     flexDirection: 'row',
-    /* - `center` works in all situations including 1 line summarys
+    /* - `center` works in all situations including 1 line summaries
      * - `flex-end` is needed only for when we have no summary
      */
     alignItems: hasSummary ? 'center' : 'flex-end',

--- a/packages/apollos-ui-kit/src/HighlightCard/index.js
+++ b/packages/apollos-ui-kit/src/HighlightCard/index.js
@@ -118,7 +118,7 @@ const renderWithSummary = (title, actionIcon, summary, hasAction) => (
 
 const HighlightCard = withIsLoading(
   ({
-    image,
+    coverImage,
     title,
     actionIcon,
     summary,
@@ -139,7 +139,7 @@ const HighlightCard = withIsLoading(
         <Image
           overlayType={'gradient-bottom'}
           customTheme={theme}
-          source={image}
+          source={coverImage}
         />
         <Content>
           {renderLabel(summary, LabelComponent, labelText, theme)}
@@ -156,7 +156,7 @@ const HighlightCard = withIsLoading(
 );
 
 HighlightCard.propTypes = {
-  image: PropTypes.oneOfType([
+  coverImage: PropTypes.oneOfType([
     PropTypes.arrayOf(ImageSourceType),
     ImageSourceType,
   ]).isRequired,

--- a/packages/apollos-ui-kit/src/Icon/__snapshots__/Icon.tests.js.snap
+++ b/packages/apollos-ui-kit/src/Icon/__snapshots__/Icon.tests.js.snap
@@ -6073,6 +6073,204 @@ exports[`The Play icon renders correctly 1`] = `
 </RCTSafeAreaView>
 `;
 
+exports[`The PlayOpaque icon renders correctly 1`] = `
+<RCTSafeAreaView
+  emulateUnlessSupported={true}
+  onLayout={[Function]}
+  style={
+    Object {
+      "bottom": 0,
+      "left": 0,
+      "position": "absolute",
+      "right": 0,
+      "top": 0,
+    }
+  }
+>
+  <View
+    onLayout={[Function]}
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  >
+    <RNSVGSvgView
+      align="xMidYMid"
+      bbHeight={32}
+      bbWidth={32}
+      height={32}
+      meetOrSlice={0}
+      minX={0}
+      minY={0}
+      style={
+        Array [
+          Object {
+            "backgroundColor": "transparent",
+            "borderWidth": 0,
+          },
+          undefined,
+          null,
+          Object {
+            "flex": 0,
+            "height": 32,
+            "width": 32,
+          },
+        ]
+      }
+      vbHeight={48}
+      vbWidth={48}
+      width={32}
+    >
+      <RNSVGGroup
+        fill={
+          Array [
+            0,
+            4278190080,
+          ]
+        }
+        fillOpacity={1}
+        fillRule={1}
+        font={Object {}}
+        matrix={
+          Array [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ]
+        }
+        opacity={1}
+        originX={0}
+        originY={0}
+        propList={Array []}
+        rotation={0}
+        scaleX={1}
+        scaleY={1}
+        skewX={0}
+        skewY={0}
+        stroke={null}
+        strokeDasharray={null}
+        strokeDashoffset={null}
+        strokeLinecap={0}
+        strokeLinejoin={0}
+        strokeMiterlimit={4}
+        strokeOpacity={1}
+        strokeWidth={1}
+        vectorEffect={0}
+        x={0}
+        y={0}
+      >
+        <RNSVGPath
+          d="M24 0a24 24 0 1 0 0 48 24 24 0 0 0 0-48z"
+          fill={
+            Array [
+              0,
+              4281348144,
+            ]
+          }
+          fillOpacity={0.1}
+          fillRule={1}
+          matrix={
+            Array [
+              1,
+              0,
+              0,
+              1,
+              0,
+              0,
+            ]
+          }
+          opacity={1}
+          originX={0}
+          originY={0}
+          propList={
+            Array [
+              "fill",
+              "fillOpacity",
+            ]
+          }
+          rotation={0}
+          scaleX={1}
+          scaleY={1}
+          skewX={0}
+          skewY={0}
+          stroke={null}
+          strokeDasharray={null}
+          strokeDashoffset={null}
+          strokeLinecap={0}
+          strokeLinejoin={0}
+          strokeMiterlimit={4}
+          strokeOpacity={1}
+          strokeWidth={1}
+          vectorEffect={0}
+          x={0}
+          y={0}
+        />
+        <RNSVGPath
+          d="M20 15.3c0-1.3.9-1.7 2-1l11 8c1.1.8 1.1 2 0 2.8l-11 8.4c-1.1.9-2 .5-2-.8V15.3z"
+          fill={
+            Array [
+              0,
+              4281348144,
+            ]
+          }
+          fillOpacity={1}
+          fillRule={1}
+          matrix={
+            Array [
+              1,
+              0,
+              0,
+              1,
+              0,
+              0,
+            ]
+          }
+          opacity={1}
+          originX={0}
+          originY={0}
+          propList={
+            Array [
+              "fill",
+            ]
+          }
+          rotation={0}
+          scaleX={1}
+          scaleY={1}
+          skewX={0}
+          skewY={0}
+          stroke={null}
+          strokeDasharray={null}
+          strokeDashoffset={null}
+          strokeLinecap={0}
+          strokeLinejoin={0}
+          strokeMiterlimit={4}
+          strokeOpacity={1}
+          strokeWidth={1}
+          vectorEffect={0}
+          x={0}
+          y={0}
+        />
+      </RNSVGGroup>
+    </RNSVGSvgView>
+  </View>
+</RCTSafeAreaView>
+`;
+
 exports[`The PlaySolid icon renders correctly 1`] = `
 <RCTSafeAreaView
   emulateUnlessSupported={true}

--- a/packages/apollos-ui-kit/src/theme/icons/PlayOpaque.js
+++ b/packages/apollos-ui-kit/src/theme/icons/PlayOpaque.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Svg, { Path } from 'react-native-svg';
+
+import makeIcon from '../../Icon/makeIcon';
+
+const Icon = makeIcon(({ size = 32, fill, ...otherProps } = {}) => (
+  <Svg width={size} height={size} viewBox="0 0 48 48" {...otherProps}>
+    <Path
+      fill={fill}
+      fillOpacity=".1"
+      d="M24 0a24 24 0 1 0 0 48 24 24 0 0 0 0-48z"
+    />
+    <Path
+      fill={fill}
+      d="M20 15.3c0-1.3.9-1.7 2-1l11 8c1.1.8 1.1 2 0 2.8l-11 8.4c-1.1.9-2 .5-2-.8V15.3z"
+    />
+  </Svg>
+));
+
+Icon.propTypes = {
+  size: PropTypes.number,
+  fill: PropTypes.string,
+};
+
+export default Icon;

--- a/packages/apollos-ui-kit/src/theme/icons/index.js
+++ b/packages/apollos-ui-kit/src/theme/icons/index.js
@@ -35,6 +35,7 @@ export Mute from './Mute';
 export Pause from './Pause';
 export Pin from './Pin';
 export Play from './Play';
+export PlayOpaque from './PlayOpaque';
 export PlaySolid from './PlaySolid';
 export Pray from './Pray';
 export Print from './Print';


### PR DESCRIPTION
## DESCRIPTION
The props for `FeaturedCard` and `HighlightCard` did not match `ContentCard`. This updates them so that all three card components have the same API and in theory could use the same `ConnectedComponent`. 

This also sneaks an update into `HighlightCard` by adding and using the correct `PlayOpaque` icon for that card.

<img src="https://user-images.githubusercontent.com/2053547/61967650-f404dc00-afa3-11e9-9ddd-37d50acef924.png" width="50%" /><img src="https://user-images.githubusercontent.com/2053547/61967683-01ba6180-afa4-11e9-8252-479e7dfa4d27.png" width="50%" />



### What design trade-offs/decisions were made?
None! All of @michael-riddering's subtle design differences are acknowledged and faithfully upheld.

### How do I test this PR?
Stories are present to show these prop changes still work.

### What automated tests did you write?
100% coverage.

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS ~and Android~
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
