### PR TITLE
Fixes wrong campus being selected under certain conditions

### DIFF
--- a/packages/apolloschurchapp/src/user-settings/Locations/MapView.js
+++ b/packages/apolloschurchapp/src/user-settings/Locations/MapView.js
@@ -47,6 +47,7 @@ class MapView extends Component {
         longitude: PropTypes.number.isRequired,
       })
     ),
+    isLoading: PropTypes.bool.isRequired,
     onLocationSelect: PropTypes.func.isRequired,
     initialRegion: PropTypes.shape({
       latitude: PropTypes.number.isRequired,
@@ -82,34 +83,44 @@ class MapView extends Component {
     if (oldProps.userLocation !== this.props.userLocation) {
       this.updateCoordinates({ value: this.previousScrollPosition });
     }
+    if (oldProps.isLoading === true && this.props.isLoading === false) {
+      this.setCurrentCampus();
+    }
   }
 
   get contentContainerStyle() {
     return { paddingHorizontal: this.props.theme.sizing.baseUnit * 0.75 }; // pad cards from edge of screen but account for card margin
   }
 
+  get cardIndex() {
+    return Math.floor(this.previousScrollPosition / CARD_WIDTH + 0.3); // animate 30% away from landing on the next item;
+  }
+
+  setCurrentCampus() {
+    const campus = this.props.campuses[this.cardIndex];
+    this.setState({ campus });
+    return campus;
+  }
+
   updateCoordinates = ({ value }) => {
     this.previousScrollPosition = value;
-    const cardIndex = Math.floor(value / CARD_WIDTH + 0.3); // animate 30% away from landing on the next item;
-    const campus = this.props.campuses[cardIndex];
-    this.setState({ campus });
+
+    const campus = this.setCurrentCampus();
+
+    const { userLocation } = this.props;
     if (!campus) {
-      this.map.fitToCoordinates(
-        [...this.props.campuses, this.props.userLocation],
-        {
-          edgePadding: {
-            top: 100,
-            left: 100,
-            right: 100,
-            // This is higher to avoid the campus cards (baseUnit * 6) on the bottom
-            bottom: 100 + this.props.theme.sizing.baseUnit * 12,
-          },
-        }
-      );
+      this.map.fitToCoordinates([...this.props.campuses, userLocation], {
+        edgePadding: {
+          top: 100,
+          left: 100,
+          right: 100,
+          // This is higher to avoid the campus cards (baseUnit * 6) on the bottom
+          bottom: 100 + this.props.theme.sizing.baseUnit * 12,
+        },
+      });
       return;
     }
 
-    const { userLocation } = this.props;
     this.map.fitToCoordinates([campus, userLocation], {
       edgePadding: {
         top: 100,

--- a/packages/apolloschurchapp/src/user-settings/Locations/MapView.js
+++ b/packages/apolloschurchapp/src/user-settings/Locations/MapView.js
@@ -47,7 +47,6 @@ class MapView extends Component {
         longitude: PropTypes.number.isRequired,
       })
     ),
-    isLoading: PropTypes.bool.isRequired,
     onLocationSelect: PropTypes.func.isRequired,
     initialRegion: PropTypes.shape({
       latitude: PropTypes.number.isRequired,
@@ -69,10 +68,6 @@ class MapView extends Component {
     }),
   };
 
-  state = {
-    campus: null,
-  };
-
   animation = new Animated.Value(0);
 
   componentDidMount() {
@@ -83,29 +78,24 @@ class MapView extends Component {
     if (oldProps.userLocation !== this.props.userLocation) {
       this.updateCoordinates({ value: this.previousScrollPosition });
     }
-    if (oldProps.isLoading === true && this.props.isLoading === false) {
-      this.setCurrentCampus();
-    }
   }
 
   get contentContainerStyle() {
     return { paddingHorizontal: this.props.theme.sizing.baseUnit * 0.75 }; // pad cards from edge of screen but account for card margin
   }
 
-  get cardIndex() {
-    return Math.floor(this.previousScrollPosition / CARD_WIDTH + 0.3); // animate 30% away from landing on the next item;
-  }
-
-  setCurrentCampus() {
-    const campus = this.props.campuses[this.cardIndex];
-    this.setState({ campus });
+  get currentCampus() {
+    const cardIndex = Math.floor(
+      this.previousScrollPosition / CARD_WIDTH + 0.3
+    ); // animate 30% away from landing on the next item;
+    const campus = this.props.campuses[cardIndex];
     return campus;
   }
 
   updateCoordinates = ({ value }) => {
     this.previousScrollPosition = value;
 
-    const campus = this.setCurrentCampus();
+    const campus = this.currentCampus;
 
     const { userLocation } = this.props;
     if (!campus) {
@@ -210,7 +200,7 @@ class MapView extends Component {
                 pill={false}
                 type="secondary"
                 onPress={() =>
-                  onLocationSelect(this.state.campus || campuses[0])
+                  onLocationSelect(this.currentCampus || campuses[0])
                 }
               />
             </PaddedView>


### PR DESCRIPTION

![2019-08-01 09 20 51](https://user-images.githubusercontent.com/1637694/62296729-b689ce00-b43d-11e9-870d-1c7c86917255.gif)
## DESCRIPTION

### What does this PR do, or why is it needed?
Fixes issue where the wrong campus would be a selected, if a user's location was received and new data was fetched after the map rendered, and the user never interacted with the campus selector. 

This was due to `this.state.campuses` never been updated with the new "index 0" campus. Removing campus from state and calculating the current campus on the fly fixes this issue. 

### What design trade-offs/decisions were made?

n/a

### How do I test this PR?

1. Open the location finder from a geolocation close to either Dallas or North Carolina 
2. Watch as the first campus card (cincinnati) changes to either Dallas or Anderson
3. Click the select campus button
  - your sellected campus should be either dallas or anderson (whatever you are closest to)

### What automated tests did you write?
n/a

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Closes #946 
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
