### PR TITLE
Adds Navigating to auth when logging out

### DIFF
--- a/packages/apolloschurchapp/src/tabs/connect/Connect.js
+++ b/packages/apolloschurchapp/src/tabs/connect/Connect.js
@@ -1,46 +1,12 @@
 import React, { PureComponent } from 'react';
 import { ScrollView, SafeAreaView } from 'react-native';
-import { Query } from 'react-apollo';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 
-import { LoginButton, GET_LOGIN_STATE } from '@apollosproject/ui-auth';
-import {
-  H1,
-  BodyText,
-  Paragraph,
-  BackgroundView,
-  withTheme,
-  styled,
-  Icon,
-  PaddedView,
-} from '@apollosproject/ui-kit';
+import { BackgroundView, styled } from '@apollosproject/ui-kit';
 import ActionTable from './ActionTable';
 import Toolbar from './Toolbar';
 import { UserAvatarHeaderConnected } from './UserAvatarHeader';
 import { RecentlyLikedTileFeedConnected } from './RecentlyLikedTileFeed';
-
-const Title = styled(({ theme }) => ({
-  color: theme.colors.primary,
-  paddingBottom: theme.helpers.verticalRhythm(1.5),
-}))(H1);
-
-const BrandIcon = withTheme(({ theme }) => ({
-  name: 'brand-icon',
-  size: theme.sizing.baseUnit * 2.25,
-  marginBottom: theme.sizing.baseUnit,
-  fill: theme.colors.primary,
-}))(Icon);
-
-const Header = styled(({ theme }) => ({
-  paddingBottom: theme.sizing.baseUnit * 1.5,
-  backgroundColor: theme.colors.background.paper,
-  paddingTop: theme.sizing.baseUnit * 4,
-}))(PaddedView);
-
-const StyledLoginButton = styled(({ theme }) => ({
-  marginVertical: theme.sizing.baseUnit,
-}))(LoginButton);
 
 const StyledScrollView = styled(({ theme }) => ({
   marginVertical: theme.sizing.baseUnit,
@@ -62,46 +28,14 @@ class Connect extends PureComponent {
   render() {
     return (
       <BackgroundView>
-        <Query query={GET_LOGIN_STATE}>
-          {({ data }) => {
-            if (get(data, 'isLoggedIn', false))
-              return (
-                <SafeAreaView>
-                  <StyledScrollView>
-                    <UserAvatarHeaderConnected key="UserAvatarHeaderConnected" />
-                    <RecentlyLikedTileFeedConnected key="RecentlyLikedTileFeedConnected" />
-                    <Toolbar />
-                    <ActionTable />
-                  </StyledScrollView>
-                </SafeAreaView>
-              );
-            return (
-              <SafeAreaView>
-                <ScrollView>
-                  <Header>
-                    <BrandIcon />
-                    <Title>Connect!</Title>
-                    <Paragraph>
-                      <BodyText>
-                        Our mission is to help you connect to others as well as
-                        help you in your walk with Christ.
-                      </BodyText>
-                    </Paragraph>
-                    <Paragraph>
-                      <BodyText>
-                        By joining this community, you will unlock amazing
-                        features like; curated content and devotionals, simple
-                        event registration, and easy online giving!
-                      </BodyText>
-                    </Paragraph>
-                    <StyledLoginButton />
-                  </Header>
-                  <ActionTable />
-                </ScrollView>
-              </SafeAreaView>
-            );
-          }}
-        </Query>
+        <SafeAreaView>
+          <StyledScrollView>
+            <UserAvatarHeaderConnected key="UserAvatarHeaderConnected" />
+            <RecentlyLikedTileFeedConnected key="RecentlyLikedTileFeedConnected" />
+            <Toolbar />
+            <ActionTable />
+          </StyledScrollView>
+        </SafeAreaView>
       </BackgroundView>
     );
   }

--- a/packages/apolloschurchapp/src/user-settings/index.js
+++ b/packages/apolloschurchapp/src/user-settings/index.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-
+import { StackActions, NavigationActions } from 'react-navigation';
 import PropTypes from 'prop-types';
 import { Query, Mutation } from 'react-apollo';
 
@@ -134,7 +134,22 @@ class UserSettings extends PureComponent {
                           <Touchable
                             onPress={async () => {
                               await handleLogout();
-                              await this.props.navigation.navigate('Connect');
+                              // This resets the navigation stack, and the navigates to the first auth screen.
+                              // This ensures that user isn't navigated to a subscreen of Auth, like the pin entry screen.
+                              await this.props.navigation.dispatch(
+                                StackActions.reset({
+                                  index: 0,
+                                  key: null,
+                                  actions: [
+                                    NavigationActions.navigate({
+                                      routeName: 'Auth',
+                                      action: NavigationActions.navigate({
+                                        routeName: 'AuthSMSPhoneEntryConnected',
+                                      }),
+                                    }),
+                                  ],
+                                })
+                              );
                             }}
                           >
                             <Cell>


### PR DESCRIPTION
## DESCRIPTION

![2019-08-01 10 43 48](https://user-images.githubusercontent.com/1637694/62305143-59961400-b44d-11e9-8b35-e32dc49fbb9c.gif)

### What does this PR do, or why is it needed?

Currently, when logging out, the user is taken to a new version of the connect tab that hides user details. The user can still click around inside the app. 

Seeing as the is taking a more "logged in focused" experience, when a user logs out we should take them straight to the log in page so they have a chance to login again. 

### What design trade-offs/decisions were made?

### How do I test this PR?

1. Login.
2. Logout.
3. You should be taken to the Auth screen, rather than the connect tab. 

### What automated tests did you write?

n/a

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Closes #940 
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
