### PR TITLE
Fixes Back/Close doing the same thing inside devotionals

### DIFF
--- a/packages/apolloschurchapp/src/content-single/NavigationHeader.js
+++ b/packages/apolloschurchapp/src/content-single/NavigationHeader.js
@@ -4,24 +4,9 @@ import { ModalViewHeader } from '@apollosproject/ui-kit';
 
 const NavigationHeader = ({ scene, navigation }) => {
   let onBack = null;
-  if (scene.index > 0) onBack = () => navigation.goBack();
+  if (scene.index > 0) onBack = () => navigation.pop();
   const onClose = () => {
-    // Since we're dealing with nested navigators, we have to trigger two actions:
-    // One action that pops us to the top of the modal's navigation history
-    // Another action that pops us one more level, which triggers the modal to close.
-    //
-    // FWIW, calling something like `.pop(scenes.length + 1)` or something does not work,
-    // as that results in the same thing as `.popToTop()`. React-Navigation must have some special-case
-    // handling for calling `.pop()` at the top of a nested navigators stack.
-    //
-    // Because react (or redux?) chains renders, this still results in only one clean animation!
-    //
-    // This "double pop" is only needed when we are already deep in a navigation stack.
-    // In ReactNavigation, we could look at using "goBack('ContentSingle')"
-    if (scene.index > 0) {
-      navigation.popToTop();
-    }
-    navigation.pop();
+    navigation.goBack();
   };
 
   return <ModalViewHeader onClose={onClose} onBack={onBack} navigationHeader />;


### PR DESCRIPTION
## DESCRIPTION

|![2019-08-02 13 47 25](https://user-images.githubusercontent.com/1637694/62388849-63db0f80-b52c-11e9-9d2d-df2f5cd61000.gif)|
![2019-08-02 13 47 13](https://user-images.githubusercontent.com/1637694/62388863-6b021d80-b52c-11e9-96b5-1c002803aa2c.gif)|![2019-08-02 13 46 55](https://user-images.githubusercontent.com/1637694/62388885-73f2ef00-b52c-11e9-9581-521bd94fc08e.gif)|
|----------------------------------------------------------|-----------------------------------------------------------|---|

### What does this PR do, or why is it needed?

The back and close button currently do the same thing when looking at nested content cards. This PR fixes that by calling the correct functions from `ReactNavigation`, and removing some complexity along the way. 

### What design trade-offs/decisions were made?

n/a

### How do I test this PR?

1. Open a nested devotional, like the jeremiah series. 
2. Click a few layers deep, then try and exit
3. Click a few layers deep, then try and go back.

### What automated tests did you write?

n/a

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Closes #949 
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
