### PR TITLE
Fix using first instead of top in sermon children algorithm

### DIFF
--- a/packages/apollos-data-connector-rock/src/features/data-source.js
+++ b/packages/apollos-data-connector-rock/src/features/data-source.js
@@ -112,7 +112,7 @@ Make sure you structure your algorithm entry as \`{ type: 'CONTENT_CHANNEL', aru
     }
 
     const cursor = await ContentItem.getCursorByParentContentItemId(sermon.id);
-    const items = limit ? await cursor.first(limit).get() : await cursor.get();
+    const items = limit ? await cursor.top(limit).get() : await cursor.get();
 
     return items.map((item, i) => ({
       id: createGlobalId(`${item.id}${i}`, 'ActionListAction'),


### PR DESCRIPTION
## DESCRIPTION
Fixes this issue: 

![image](https://user-images.githubusercontent.com/1637694/62567285-e2032300-b858-11e9-852e-40a42de2786f.png)

`first` returns `null` or an item. `top` returns a cursor. We want the cursor. 

### What does this PR do, or why is it needed?

### What design trade-offs/decisions were made?

### How do I test this PR?

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
