### PR TITLE
Adds easy configuration options for bulletin list. 

### DIFF
--- a/packages/apollos-church-api/config.yml
+++ b/packages/apollos-church-api/config.yml
@@ -108,7 +108,19 @@ ROCK_MAPPINGS:
 
   SERMON_CHANNEL_ID: 5
 
-  HOME_FEATURE_CHANNEL_ID: 13
+HOME_FEATURES:
+  -
+    title: FOR YOU
+    algorithms: [SERMON_CHILDREN, PERSONA_FEED]
+    subtitle: Explore what God calls you to today
+  -
+    title: BULLETIN
+    subtitle: What's happening at apollos?
+    algorithms:
+      -
+        type: CONTENT_CHANNEL
+        arguments:
+          contentChannelId: 13
 
 # Default mapping of field types -> ids. There's probably no reason to edit this.
 ROCK_CONSTANTS:

--- a/packages/apollos-data-connector-rock/__mocks__/@apollosproject/config.js
+++ b/packages/apollos-data-connector-rock/__mocks__/@apollosproject/config.js
@@ -33,6 +33,25 @@ ApolloServer.loadJs({
     API_TOKEN: 'some-rock-token',
     IMAGE_URL: 'https://apollosrock.newspring.cc/GetImage.ashx',
   },
+  HOME_FEATURES: [
+    {
+      algorithms: ['SERMON_CHILDREN', 'PERSONA_FEED'],
+      subtitle: 'Explore what God calls you to today',
+      title: 'FOR YOU',
+    },
+    {
+      subtitle: "What's happening at apollos?",
+      algorithms: [
+        {
+          type: 'CONTENT_CHANNEL',
+          arguments: {
+            contentChannelId: 13,
+          },
+        },
+      ],
+      title: 'BULLETIN',
+    },
+  ],
 });
 
 export default ApolloServer;

--- a/packages/apollos-data-connector-rock/src/features/data-source.js
+++ b/packages/apollos-data-connector-rock/src/features/data-source.js
@@ -1,6 +1,7 @@
 import { flatten, get } from 'lodash';
 import RockApolloDataSource from '@apollosproject/rock-apollo-data-source';
 import { createGlobalId } from '@apollosproject/server-core';
+import ApollosConfig from '@apollosproject/config';
 
 export default class Features extends RockApolloDataSource {
   resource = '';
@@ -133,5 +134,13 @@ Make sure you structure your algorithm entry as \`{ type: 'CONTENT_CHANNEL', aru
           `${content.replace(/<[^>]*>?/gm, '')} ${reference}`
       )
       .join('\n\n');
+  }
+
+  getHomeFeedFeatures() {
+    return Promise.all(
+      get(ApollosConfig, 'HOME_FEATURES', []).map((featureConfig) =>
+        this.createActionListFeature(featureConfig)
+      )
+    );
   }
 }

--- a/packages/apollos-data-connector-rock/src/features/resolver.js
+++ b/packages/apollos-data-connector-rock/src/features/resolver.js
@@ -1,6 +1,3 @@
-import ApollosConfig from '@apollosproject/config';
-
-const { ROCK_MAPPINGS } = ApollosConfig;
 export default {
   WeekendContentItem: {
     features: (root, args, { dataSources: { ContentItem } }) =>
@@ -29,27 +26,7 @@ export default {
     }),
   },
   Query: {
-    userFeedFeatures: async (root, args, context) => {
-      const { Features } = context.dataSources;
-      // Generate a feature to show the user on the home screen.
-      const personaFeature = await Features.createActionListFeature({
-        algorithms: ['SERMON_CHILDREN', 'PERSONA_FEED'],
-        title: 'FOR YOU',
-        subtitle: 'Explore what God calls you to today',
-      });
-      const contentChannelFeature = await Features.createActionListFeature({
-        algorithms: [
-          {
-            type: 'CONTENT_CHANNEL',
-            arguments: {
-              contentChannelId: ROCK_MAPPINGS.HOME_FEATURE_CHANNEL_ID,
-            },
-          },
-        ],
-        title: 'BULLETIN',
-        subtitle: "What's happening at apollos?",
-      });
-      return [personaFeature, contentChannelFeature];
-    },
+    userFeedFeatures: async (root, args, { dataSources: { Features } }) =>
+      Features.getHomeFeedFeatures(),
   },
 };


### PR DESCRIPTION
## DESCRIPTION

![Simulator Screen Shot - iPhone X - 2019-08-12 at 10 58 21](https://user-images.githubusercontent.com/1637694/62874963-2165bf80-bcf0-11e9-994f-9193357f1343.png)

### What does this PR do, or why is it needed?

Changes the configuration of the home features from being statically defined in a resolver, to being dynamically assigned inside the config.yml. The format is still not documented, and you may need to override the resolver anyway in order to add advanced features, but this way users will be able to edit the "core" configuration easily without needing to change code. 

### What design trade-offs/decisions were made?

n/a

### How do I test this PR?

1. Open the app.
2. Check the content on the home feed.

### What automated tests did you write?

Existing automated tests pass. 

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Closes #900
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
