### PR TITLE
Configs tests to only run story generation when actually publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "release": "lerna publish --no-push --force-publish && echo \"Release has been tagged!\nPlease look over the CHANGELOG.md file, and use 'git commit -amend' to amend any edits.\nWhen done, be sure to 'git push --tags' and create a release PR\"",
     "release:canary": "lerna publish --canary --yes",
     "preversion": "./scripts/update-change-log.sh",
-    "prepublish": "lerna run build && lerna run generate-stories",
+    "prepublishOnly": "lerna run build && lerna run generate-stories",
     "publish-schema": "apollo schema:publish --endpoint=\"https://apollos-church-api.now.sh\" --key=$ENGINE_API_KEY",
     "deploy": "now --public --team apolloschurch --token $NOW_TOKEN --docker && now alias --team apolloschurch --token $NOW_TOKEN && now rm apollos-church-api --team apolloschurch --safe --yes --token $NOW_TOKEN && npm run publish-schema",
     "nuke": "./scripts/boom.sh && yarn nuke:node && yarn nuke:cache",


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

All test stages currently are running generate-snapshots and an additional build needlessly, because `prepublish` runs both on `install` and on `publish`. Using `prepublishOnly` limits the command to run on `publish` only, which is the intended behavior. 

### What design trade-offs/decisions were made?

n/a

### How do I test this PR?

Check that the build time is less than the average build time (might only be like 30 seconds, but hopefully more!)

### What automated tests did you write?

all of them

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [x] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
