### PR TITLE
Fixes phone entry keyboard covering link

### DIFF
--- a/packages/apollos-ui-auth/src/SMS/PhoneEntry.js
+++ b/packages/apollos-ui-auth/src/SMS/PhoneEntry.js
@@ -63,7 +63,6 @@ const PhoneEntry = ({
             <PromptText padded>{smsPromptText}</PromptText>
 
             <TextInput
-              autoFocus
               autoComplete={'tel'}
               label={'Mobile Number'}
               type={'phone'}

--- a/packages/apollos-ui-auth/src/SMS/__snapshots__/PhoneEntry.tests.js.snap
+++ b/packages/apollos-ui-auth/src/SMS/__snapshots__/PhoneEntry.tests.js.snap
@@ -279,7 +279,6 @@ exports[`The Auth PhoneEntry component should render 1`] = `
                         <TextInput
                           allowFontScaling={true}
                           autoComplete="tel"
-                          autoFocus={true}
                           editable={true}
                           enablesReturnKeyAutomatically={true}
                           keyboardType="phone-pad"
@@ -697,7 +696,6 @@ exports[`The Auth PhoneEntry component should render a custom smsPolicyInfo text
                         <TextInput
                           allowFontScaling={true}
                           autoComplete="tel"
-                          autoFocus={true}
                           editable={true}
                           enablesReturnKeyAutomatically={true}
                           keyboardType="phone-pad"
@@ -1115,7 +1113,6 @@ exports[`The Auth PhoneEntry component should render as disabled 1`] = `
                         <TextInput
                           allowFontScaling={true}
                           autoComplete="tel"
-                          autoFocus={true}
                           editable={true}
                           enablesReturnKeyAutomatically={true}
                           keyboardType="phone-pad"
@@ -1595,7 +1592,6 @@ exports[`The Auth PhoneEntry component should render in a loading state 1`] = `
                         <TextInput
                           allowFontScaling={true}
                           autoComplete="tel"
-                          autoFocus={true}
                           editable={true}
                           enablesReturnKeyAutomatically={true}
                           keyboardType="phone-pad"
@@ -2069,7 +2065,6 @@ exports[`The Auth PhoneEntry component should render in a next button 1`] = `
                         <TextInput
                           allowFontScaling={true}
                           autoComplete="tel"
-                          autoFocus={true}
                           editable={true}
                           enablesReturnKeyAutomatically={true}
                           keyboardType="phone-pad"
@@ -2549,7 +2544,6 @@ exports[`The Auth PhoneEntry component should render in an error state 1`] = `
                         <TextInput
                           allowFontScaling={true}
                           autoComplete="tel"
-                          autoFocus={true}
                           editable={true}
                           enablesReturnKeyAutomatically={true}
                           keyboardType="phone-pad"
@@ -2980,7 +2974,6 @@ exports[`The Auth PhoneEntry component should render with a custom alternateLogi
                         <TextInput
                           allowFontScaling={true}
                           autoComplete="tel"
-                          autoFocus={true}
                           editable={true}
                           enablesReturnKeyAutomatically={true}
                           keyboardType="phone-pad"
@@ -3428,7 +3421,6 @@ exports[`The Auth PhoneEntry component should render with a custom authTitleText
                         <TextInput
                           allowFontScaling={true}
                           autoComplete="tel"
-                          autoFocus={true}
                           editable={true}
                           enablesReturnKeyAutomatically={true}
                           keyboardType="phone-pad"
@@ -3846,7 +3838,6 @@ exports[`The Auth PhoneEntry component should render with a custom smsPromptText
                         <TextInput
                           allowFontScaling={true}
                           autoComplete="tel"
-                          autoFocus={true}
                           editable={true}
                           enablesReturnKeyAutomatically={true}
                           keyboardType="phone-pad"
@@ -4264,7 +4255,6 @@ exports[`The Auth PhoneEntry component should render with a value 1`] = `
                         <TextInput
                           allowFontScaling={true}
                           autoComplete="tel"
-                          autoFocus={true}
                           editable={true}
                           enablesReturnKeyAutomatically={true}
                           keyboardType="phone-pad"
@@ -4683,7 +4673,6 @@ exports[`The Auth PhoneEntry component should render with an alternate login opt
                         <TextInput
                           allowFontScaling={true}
                           autoComplete="tel"
-                          autoFocus={true}
                           editable={true}
                           enablesReturnKeyAutomatically={true}
                           keyboardType="phone-pad"


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Currently on the screen to enter your phone number, the text input is autofocused which covers the link to the alternate login flow.  This changes to text input to not autofocus.

### What design trade-offs/decisions were made?

Just to allow the text input to not autofocus. This makes the user click on the text input to begin entering their phone, but also allows them to see the whole screen beforehand. On smaller phone sizes, much of the text was being cut off.

### How do I test this PR?

Open up a sim and go through the login flow.

### What automated tests did you write?

N/A

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
