### PR TITLE
Fixes Apple Email Warnings

### DIFF
--- a/packages/apolloschurchapp/ios/apolloschurchapp/Info.plist
+++ b/packages/apolloschurchapp/ios/apolloschurchapp/Info.plist
@@ -55,8 +55,10 @@
 	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>$(PRODUCT_NAME) would like to use your camera (for uploading profile pictures)</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>$(PRODUCT_NAME) would like to use your location for determining your closest campus</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string />
+	<string>$(PRODUCT_NAME) would like to use your location for determining your closest campus</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>$(PRODUCT_NAME) would like to your microphone (for videos)</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR should stop the emails we get from Apple telling us that we're missing things in our `info.plist`.

### What design trade-offs/decisions were made?
N/A

### How do I test this PR?
You really can't. I guess just merge it and then see if the Apple emails remove the `info.plist` warnings.

### What automated tests did you write?
N/A

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Closes [tag-issues-here]
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
