### PR TITLE
Adds Explicit Apollo Engine Config

### DIFF
--- a/packages/apollos-church-api/config.yml
+++ b/packages/apollos-church-api/config.yml
@@ -57,6 +57,9 @@ CLOUDINARY:
   # value should look something like
   # cloudinary://123123123:adkfnla_adASDv_adAS@test
   URL: ${CLOUDINARY_URL}
+ENGINE:
+  API_KEY: ${ENGINE_API_KEY}
+  SCHEMA_TAG: ${ENGINE_SCHEMA_TAG}
 
 # This key holds various properties that allow our GraphQL server to map to your Rock Instance
 ROCK_MAPPINGS:

--- a/packages/apollos-church-api/src/server.js
+++ b/packages/apollos-church-api/src/server.js
@@ -1,4 +1,5 @@
 import { ApolloServer } from 'apollo-server-express';
+import ApollosConfig from '@apollosproject/config';
 import express from 'express';
 import { RockLoggingExtension } from '@apollosproject/rock-apollo-data-source';
 
@@ -29,6 +30,8 @@ const cacheOptions = isDev
       },
     };
 
+const { ENGINE } = ApollosConfig;
+
 const apolloServer = new ApolloServer({
   typeDefs: schema,
   resolvers,
@@ -46,6 +49,10 @@ const apolloServer = new ApolloServer({
     },
   },
   ...cacheOptions,
+  engine: {
+    apiKey: ENGINE.API_KEY,
+    schemaTag: ENGINE.SCHEMA_TAG,
+  },
 });
 
 const app = express();


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

This gives visibility to the Apollo Engine configuration. Technically, this has no effect on deployed environments because the variables are pulled automatically. But I think this is still valuable to partner churches for self-documenting what's happneing. And also allows a developer to create their own environment variant just by defining the `.env` variable. For example, I could specifiy `ENGINE_SCHEMA_TAG=michael` and get data on that variant without exporting the variable to my shell.

I added this to our code, not knowing that Apollo does it automatically but think it still is not a bad idea to leave it in. We'll ultimately match our API to whatever core decides.

### What design trade-offs/decisions were made?

### How do I test this PR?

### What automated tests did you write?

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Closes [tag-issues-here]
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._