### PR TITLE
Removes Redis warnings and fixes cache keys for like counts

### DIFF
--- a/packages/apollos-data-connector-redis-cache/src/__tests__/__snapshots__/data-source.tests.js.snap
+++ b/packages/apollos-data-connector-redis-cache/src/__tests__/__snapshots__/data-source.tests.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Redis Cache constructs with Redis 1`] = `
+exports[`Redis Cache constructs with Redis env url 1`] = `
 Cache {
   "DEFAULT_TIMEOUT": 86400,
   "redis": Redis {
@@ -107,6 +107,7 @@ Cache {
     "scriptsSet": Object {},
     "status": "connecting",
   },
+  "safely": [Function],
 }
 `;
 
@@ -120,6 +121,14 @@ Array [
     },
   ],
 ]
+`;
+
+exports[`Redis Cache doesn't constructs with Redis env url 1`] = `
+Cache {
+  "DEFAULT_TIMEOUT": 86400,
+  "redis": undefined,
+  "safely": [Function],
+}
 `;
 
 exports[`Redis Cache gets data from redis 1`] = `
@@ -151,6 +160,16 @@ Array [
 exports[`Redis Cache safely handle thrown errors in get 1`] = `null`;
 
 exports[`Redis Cache safely handle thrown errors in set 1`] = `null`;
+
+exports[`Redis Cache safely handles no redis instance 1`] = `null`;
+
+exports[`Redis Cache safely handles no redis instance 2`] = `
+Array [
+  Array [
+    "Redis is not running. Cache dataSource methods will only return null",
+  ],
+]
+`;
 
 exports[`Redis Cache safely swallows errors when decrementing 1`] = `null`;
 

--- a/packages/apollos-data-connector-redis-cache/src/__tests__/data-source.tests.js
+++ b/packages/apollos-data-connector-redis-cache/src/__tests__/data-source.tests.js
@@ -1,13 +1,20 @@
 import { dataSource as Cache } from '../index';
 
 describe('Redis Cache', () => {
-  it('constructs with Redis', () => {
+  it("doesn't constructs with Redis env url", () => {
+    const cache = new Cache();
+    expect(cache).toMatchSnapshot();
+  });
+  it('constructs with Redis env url', () => {
+    process.env.REDIS_URL = 'localhost';
     const cache = new Cache();
     expect(cache).toMatchSnapshot();
     cache.redis.disconnect();
+    delete process.env.REDIS_URL;
   });
   it('gets data from redis', async () => {
     const cache = new Cache();
+    cache.redis = {};
     cache.redis.get = jest.fn(() =>
       Promise.resolve(JSON.stringify({ foo: 'bar' }))
     );
@@ -16,10 +23,10 @@ describe('Redis Cache', () => {
 
     expect(result).toMatchSnapshot();
     expect(cache.redis.get.mock.calls).toMatchSnapshot();
-    cache.redis.disconnect();
   });
   it('safely handle thrown errors in get', async () => {
     const cache = new Cache();
+    cache.redis = {};
     cache.redis.get = jest.fn(() => {
       throw new Error('Some Error');
     });
@@ -27,20 +34,32 @@ describe('Redis Cache', () => {
     const result = await cache.get({ key: 'someKey' });
 
     expect(result).toMatchSnapshot();
-    cache.redis.disconnect();
+  });
+  it('safely handles no redis instance', async () => {
+    const cache = new Cache();
+    delete cache.redis;
+
+    console._warn = console.warn;
+    console.warn = jest.fn();
+    const result = await cache.get({ key: 'someKey' });
+
+    expect(result).toMatchSnapshot();
+    expect(console.warn.mock.calls).toMatchSnapshot();
+    console.warn = console._warn;
   });
   it('sets data in redis', async () => {
     const cache = new Cache();
+    cache.redis = {};
     cache.redis.set = jest.fn(() => Promise.resolve());
 
     const result = await cache.set({ key: 'someKey', data: true });
 
     expect(result).toMatchSnapshot();
     expect(cache.redis.set.mock.calls).toMatchSnapshot();
-    cache.redis.disconnect();
   });
   it('sets data in redis using an array key', async () => {
     const cache = new Cache();
+    cache.redis = {};
     cache.redis.set = jest.fn(() => Promise.resolve());
 
     const result = await cache.set({
@@ -50,10 +69,10 @@ describe('Redis Cache', () => {
 
     expect(result).toMatchSnapshot();
     expect(cache.redis.set.mock.calls).toMatchSnapshot();
-    cache.redis.disconnect();
   });
   it('safely handle thrown errors in set', async () => {
     const cache = new Cache();
+    cache.redis = {};
     cache.redis.set = jest.fn(() => {
       throw new Error('Some Error');
     });
@@ -61,21 +80,21 @@ describe('Redis Cache', () => {
     const result = await cache.set({ key: 'someKey' });
 
     expect(result).toMatchSnapshot();
-    cache.redis.disconnect();
   });
   it('increments integers in redis', async () => {
     const cache = new Cache();
+    cache.redis = {};
     cache.redis.incr = jest.fn(() => Promise.resolve(2));
 
     const result = await cache.increment({ key: 'someKey' });
 
     expect(result).toMatchSnapshot();
     expect(cache.redis.incr.mock.calls).toMatchSnapshot();
-    cache.redis.disconnect();
   });
 
   it('safely swallows errors when incrementing', async () => {
     const cache = new Cache();
+    cache.redis = {};
     cache.redis.incr = jest.fn(() => {
       throw new Error('Some Error');
     });
@@ -83,22 +102,22 @@ describe('Redis Cache', () => {
     const result = await cache.increment({ key: 'someKey' });
 
     expect(result).toMatchSnapshot();
-    cache.redis.disconnect();
   });
 
   it('decrements integers in redis', async () => {
     const cache = new Cache();
+    cache.redis = {};
     cache.redis.decr = jest.fn(() => Promise.resolve(2));
 
     const result = await cache.decrement({ key: 'someKey' });
 
     expect(result).toMatchSnapshot();
     expect(cache.redis.decr.mock.calls).toMatchSnapshot();
-    cache.redis.disconnect();
   });
 
   it('safely swallows errors when decrementing', async () => {
     const cache = new Cache();
+    cache.redis = {};
     cache.redis.decr = jest.fn(() => {
       throw new Error('Some Error');
     });
@@ -106,6 +125,5 @@ describe('Redis Cache', () => {
     const result = await cache.decrement({ key: 'someKey' });
 
     expect(result).toMatchSnapshot();
-    cache.redis.disconnect();
   });
 });

--- a/packages/apollos-data-connector-rock/src/followings/data-source.js
+++ b/packages/apollos-data-connector-rock/src/followings/data-source.js
@@ -1,5 +1,5 @@
 import { AuthenticationError } from 'apollo-server';
-import { parseGlobalId, createGlobalId } from '@apollosproject/server-core';
+import { parseGlobalId } from '@apollosproject/server-core';
 import RockApolloDataSource from '@apollosproject/rock-apollo-data-source';
 
 export default class Followings extends RockApolloDataSource {

--- a/packages/apollos-data-connector-rock/src/followings/data-source.js
+++ b/packages/apollos-data-connector-rock/src/followings/data-source.js
@@ -40,7 +40,7 @@ export default class Followings extends RockApolloDataSource {
     });
 
     await Cache.increment({
-      key: ['likedCount', currentUser.id, nodeType.id, id],
+      key: ['likedCount', nodeType.id, id],
     });
 
     return this.get(`/Followings/${followingsId}`);
@@ -62,7 +62,7 @@ export default class Followings extends RockApolloDataSource {
     });
 
     await Cache.decrement({
-      key: ['likedCount', currentUser.id, nodeType.id, id],
+      key: ['likedCount', nodeType.id, id],
     });
 
     return this.delete(`/Followings/${nodeType.id}/${id}/${currentUser.id}`);
@@ -92,7 +92,7 @@ export default class Followings extends RockApolloDataSource {
       .get()).length;
 
     await Cache.set({
-      key: ['likedCount', createGlobalId(id, nodeType)],
+      key: ['likedCount', nodeType.id, id],
       data: count,
     });
 


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

- Changes the way Redis is loaded, so that it's only loaded if the REDIS_URL is set, and gives nice warnings if it's not (but only when the redis cache is used) 
- I never fixed some of the cachekeys on the server, so `likedCounts` weren't being cached correctly. Woops! 

### What design trade-offs/decisions were made?

n/a

### How do I test this PR?

Run the app with a `REDIS_URL` set in your .env and load the home feed, you shouldn't see any warnings. 
Run the app without a `REDIS_URL` set in your .env and load the home feed, you should see a number of warnings, but only when loading the home feed.

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
