### PR TITLE
Temporary workaround for apollos plugin auto expansion issue

### DIFF
--- a/packages/apollos-data-connector-rock/src/content-items/__tests__/__snapshots__/data-source.tests.js.snap
+++ b/packages/apollos-data-connector-rock/src/content-items/__tests__/__snapshots__/data-source.tests.js.snap
@@ -159,7 +159,7 @@ Array [
     },
   ],
   Array [
-    "Apollos/GetContentChannelItemsByIds?ids=101%2C201&loadAttributes=expanded&%24filter=%28%28%28StartDateTime%20lt%20datetime%272017-11-25T07%3A34%3A56%27%29%20or%20%28StartDateTime%20eq%20null%29%29%20and%20%28%28ExpireDateTime%20gt%20datetime%272017-11-25T07%3A34%3A56%27%29%20or%20%28ExpireDateTime%20eq%20null%29%29%29%20and%20Status%20eq%20%27Approved%27&%24orderby=Order%20asc",
+    "Apollos/GetContentChannelItemsByIds?ids=101%2C201&loadAttributes=expanded&%24filter=%28%28%28StartDateTime%20lt%20datetime%272017-11-25T07%3A34%3A56%27%29%20or%20%28StartDateTime%20eq%20null%29%29%20and%20%28%28ExpireDateTime%20gt%20datetime%272017-11-25T07%3A34%3A56%27%29%20or%20%28ExpireDateTime%20eq%20null%29%29%29%20and%20Status%20eq%20%27Approved%27&%24expand=ContentChannel&%24orderby=Order%20asc",
     Object {},
     Object {},
   ],
@@ -219,7 +219,7 @@ Array [
     },
   ],
   Array [
-    "Apollos/GetContentChannelItemsByIds?ids=101%2C201&loadAttributes=expanded&%24filter=%28%28%28StartDateTime%20lt%20datetime%272017-11-25T07%3A34%3A56%27%29%20or%20%28StartDateTime%20eq%20null%29%29%20and%20%28%28ExpireDateTime%20gt%20datetime%272017-11-25T07%3A34%3A56%27%29%20or%20%28ExpireDateTime%20eq%20null%29%29%29%20and%20Status%20eq%20%27Approved%27&%24orderby=Order%20asc",
+    "Apollos/GetContentChannelItemsByIds?ids=101%2C201&loadAttributes=expanded&%24filter=%28%28%28StartDateTime%20lt%20datetime%272017-11-25T07%3A34%3A56%27%29%20or%20%28StartDateTime%20eq%20null%29%29%20and%20%28%28ExpireDateTime%20gt%20datetime%272017-11-25T07%3A34%3A56%27%29%20or%20%28ExpireDateTime%20eq%20null%29%29%29%20and%20Status%20eq%20%27Approved%27&%24expand=ContentChannel&%24orderby=Order%20asc",
     Object {},
     Object {},
   ],
@@ -289,7 +289,7 @@ Array [
     Object {},
   ],
   Array [
-    "Apollos/GetContentChannelItemsByIds?ids=1%2C2&loadAttributes=expanded&%24filter=%28%28%28StartDateTime%20lt%20datetime%272017-11-25T07%3A34%3A56%27%29%20or%20%28StartDateTime%20eq%20null%29%29%20and%20%28%28ExpireDateTime%20gt%20datetime%272017-11-25T07%3A34%3A56%27%29%20or%20%28ExpireDateTime%20eq%20null%29%29%29%20and%20Status%20eq%20%27Approved%27&%24orderby=Order%20asc",
+    "Apollos/GetContentChannelItemsByIds?ids=1%2C2&loadAttributes=expanded&%24filter=%28%28%28StartDateTime%20lt%20datetime%272017-11-25T07%3A34%3A56%27%29%20or%20%28StartDateTime%20eq%20null%29%29%20and%20%28%28ExpireDateTime%20gt%20datetime%272017-11-25T07%3A34%3A56%27%29%20or%20%28ExpireDateTime%20eq%20null%29%29%29%20and%20Status%20eq%20%27Approved%27&%24expand=ContentChannel&%24orderby=Order%20asc",
     Object {},
     Object {},
   ],
@@ -347,7 +347,7 @@ Array [
 exports[`ContentItemsModel gets by ids using Apollos Plugin 1`] = `
 Array [
   Array [
-    "Apollos/GetContentChannelItemsByIds?ids=1%2C2&loadAttributes=expanded&%24filter=%28%28%28StartDateTime%20lt%20datetime%272017-11-25T07%3A34%3A56%27%29%20or%20%28StartDateTime%20eq%20null%29%29%20and%20%28%28ExpireDateTime%20gt%20datetime%272017-11-25T07%3A34%3A56%27%29%20or%20%28ExpireDateTime%20eq%20null%29%29%29%20and%20Status%20eq%20%27Approved%27",
+    "Apollos/GetContentChannelItemsByIds?ids=1%2C2&loadAttributes=expanded&%24filter=%28%28%28StartDateTime%20lt%20datetime%272017-11-25T07%3A34%3A56%27%29%20or%20%28StartDateTime%20eq%20null%29%29%20and%20%28%28ExpireDateTime%20gt%20datetime%272017-11-25T07%3A34%3A56%27%29%20or%20%28ExpireDateTime%20eq%20null%29%29%29%20and%20Status%20eq%20%27Approved%27&%24expand=ContentChannel",
     Object {},
     Object {},
   ],

--- a/packages/apollos-data-connector-rock/src/content-items/data-source.js
+++ b/packages/apollos-data-connector-rock/src/content-items/data-source.js
@@ -407,7 +407,14 @@ export default class ContentItem extends RockApolloDataSource {
       // Caused by an Odata node limit.
       return this.request(
         `Apollos/GetContentChannelItemsByIds?ids=${ids.join(',')}`
-      ).andFilter(this.LIVE_CONTENT());
+      )
+        .andFilter(this.LIVE_CONTENT())
+        .expand('ContentChannel'); // TODO: Fix plugin issue
+      // Right now the endpoints in our apollos plugin auto expand all properties by default
+      // If you pass a speciic expansion, the auto expansion doesn't happen.
+      // The auto expansion can cause issues if there's a circular reference,
+      // so we need to force auto expansion off for the time being by expanding an
+      // arbitrary property
     }
     return this.request()
       .filterOneOf(ids.map((id) => `Id eq ${id}`))


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Right now the endpoints in our apollos plugin auto expand all properties by default. If you pass a speciic expansion, the auto expansion doesn't happen. The auto expansion can cause issues if there's a circular reference, so we need to force auto expansion off for the time being by expanding an arbitrary property

### What design trade-offs/decisions were made?

### How do I test this PR?

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
