### PR TITLE
Fixes invalid nodes breaking search results.

### DIFF
--- a/packages/apollos-data-connector-algolia-search/src/__tests__/__snapshots__/resolver.tests.js.snap
+++ b/packages/apollos-data-connector-algolia-search/src/__tests__/__snapshots__/resolver.tests.js.snap
@@ -60,6 +60,34 @@ Object {
 }
 `;
 
+exports[`Algolia Search safely captures invalid node 1`] = `
+Object {
+  "data": Object {
+    "search": Object {
+      "edges": Array [
+        Object {
+          "coverImage": Object {
+            "sources": Array [
+              Object {
+                "uri": "#",
+              },
+            ],
+          },
+          "cursor": "659a26257a49fb2bf1446bb747bf7dd3",
+          "node": null,
+          "summary": "test summary",
+          "title": "test result",
+        },
+      ],
+      "pageInfo": Object {
+        "endCursor": "659a26257a49fb2bf1446bb747bf7dd3",
+        "startCursor": "659a26257a49fb2bf1446bb747bf7dd3",
+      },
+    },
+  },
+}
+`;
+
 exports[`Algolia Search throws error on invalid cursor 1`] = `
 Object {
   "data": Object {

--- a/packages/apollos-data-connector-algolia-search/src/__tests__/resolver.tests.js
+++ b/packages/apollos-data-connector-algolia-search/src/__tests__/resolver.tests.js
@@ -121,4 +121,34 @@ describe('Algolia Search', () => {
     const result = await graphql(schema, query, rootValue, context);
     expect(result).toMatchSnapshot();
   });
+
+  it('safely captures invalid node', async () => {
+    const query = `
+      query {
+        search(query: "test", after: "${createCursor({ position: 1 })}") {
+          edges {
+            cursor
+            title
+            summary
+            coverImage { sources { uri } }
+            node {
+              id
+            }
+          }
+          pageInfo {
+            startCursor
+            endCursor
+          }
+        }
+      }
+    `;
+    const rootValue = {};
+
+    context.models.Node.get = jest.fn(() => {
+      throw new Error("Item doesn't exist");
+    });
+
+    const result = await graphql(schema, query, rootValue, context);
+    expect(result).toMatchSnapshot();
+  });
 });

--- a/packages/apollos-data-connector-algolia-search/src/resolver.js
+++ b/packages/apollos-data-connector-algolia-search/src/resolver.js
@@ -10,8 +10,16 @@ const resolver = {
     pageInfo: (edges) => withEdgePagination({ edges }),
   },
   SearchResult: {
-    node: ({ id }, _, { models, dataSources }, { schema }) =>
-      models.Node.get(id, dataSources, schema),
+    node: async ({ id }, _, { models, dataSources }, { schema }) => {
+      try {
+        return await models.Node.get(id, dataSources, schema);
+      } catch (e) {
+        // Right now we don't have a good mechanism to flush deleted items from the search index.
+        // This helps make sure we don't return something unresolvable.
+        console.log(`Error fetching search result ${id}`, e);
+        return null;
+      }
+    },
   },
 };
 

--- a/packages/apolloschurchapp/src/tabs/discover/SearchFeed/index.js
+++ b/packages/apolloschurchapp/src/tabs/discover/SearchFeed/index.js
@@ -34,7 +34,9 @@ const SearchFeed = withNavigation(({ navigation, searchText }) => (
     {({ loading, error, data, refetch }) => (
       <StyledFeedView
         ListItemComponent={ContentCardConnected}
-        content={get(data, 'search.edges', []).map((edge) => edge.node)}
+        content={get(data, 'search.edges', [])
+          .map((edge) => edge.node)
+          .filter((node) => !!node)}
         ListEmptyComponent={() => <NoResults searchText={searchText} />}
         hasContent={get(data, 'search.edges', []).length}
         isLoading={loading}


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Currently because of how we index, items that are deleted (or are in some other way invalid) can break search results. We don't have a good mechanism for clearing those bad items out at the moment they become invalid, so this PR adds some safety around how we retrieve those items. (Previously this would break all search results) 

### What design trade-offs/decisions were made?

n/a 

### How do I test this PR?

1. Search for a term
2. Delete one of the items in the results Rock
3. Search for the term in the app, the item should no longer show up.

### What automated tests did you write?

Tests over new resolver functionality.

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [x] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
