### PR TITLE
Adds Autofocus to SMS Login

### DIFF
--- a/packages/apollos-ui-auth/src/SMS/PhoneEntry.js
+++ b/packages/apollos-ui-auth/src/SMS/PhoneEntry.js
@@ -63,6 +63,7 @@ const PhoneEntry = ({
             <PromptText padded>{smsPromptText}</PromptText>
 
             <TextInput
+              autofocus
               autoComplete={'tel'}
               label={'Mobile Number'}
               type={'phone'}

--- a/packages/apollos-ui-auth/src/SMS/__snapshots__/PhoneEntry.tests.js.snap
+++ b/packages/apollos-ui-auth/src/SMS/__snapshots__/PhoneEntry.tests.js.snap
@@ -247,6 +247,7 @@ exports[`The Auth PhoneEntry component should render 1`] = `
                     <TextInput
                       allowFontScaling={true}
                       autoComplete="tel"
+                      autofocus={true}
                       editable={true}
                       enablesReturnKeyAutomatically={true}
                       keyboardType="phone-pad"
@@ -630,6 +631,7 @@ exports[`The Auth PhoneEntry component should render a custom smsPolicyInfo text
                     <TextInput
                       allowFontScaling={true}
                       autoComplete="tel"
+                      autofocus={true}
                       editable={true}
                       enablesReturnKeyAutomatically={true}
                       keyboardType="phone-pad"
@@ -1013,6 +1015,7 @@ exports[`The Auth PhoneEntry component should render as disabled 1`] = `
                     <TextInput
                       allowFontScaling={true}
                       autoComplete="tel"
+                      autofocus={true}
                       editable={true}
                       enablesReturnKeyAutomatically={true}
                       keyboardType="phone-pad"
@@ -1458,6 +1461,7 @@ exports[`The Auth PhoneEntry component should render in a loading state 1`] = `
                     <TextInput
                       allowFontScaling={true}
                       autoComplete="tel"
+                      autofocus={true}
                       editable={true}
                       enablesReturnKeyAutomatically={true}
                       keyboardType="phone-pad"
@@ -1897,6 +1901,7 @@ exports[`The Auth PhoneEntry component should render in a next button 1`] = `
                     <TextInput
                       allowFontScaling={true}
                       autoComplete="tel"
+                      autofocus={true}
                       editable={true}
                       enablesReturnKeyAutomatically={true}
                       keyboardType="phone-pad"
@@ -2342,6 +2347,7 @@ exports[`The Auth PhoneEntry component should render in an error state 1`] = `
                     <TextInput
                       allowFontScaling={true}
                       autoComplete="tel"
+                      autofocus={true}
                       editable={true}
                       enablesReturnKeyAutomatically={true}
                       keyboardType="phone-pad"
@@ -2738,6 +2744,7 @@ exports[`The Auth PhoneEntry component should render with a custom alternateLogi
                     <TextInput
                       allowFontScaling={true}
                       autoComplete="tel"
+                      autofocus={true}
                       editable={true}
                       enablesReturnKeyAutomatically={true}
                       keyboardType="phone-pad"
@@ -3151,6 +3158,7 @@ exports[`The Auth PhoneEntry component should render with a custom authTitleText
                     <TextInput
                       allowFontScaling={true}
                       autoComplete="tel"
+                      autofocus={true}
                       editable={true}
                       enablesReturnKeyAutomatically={true}
                       keyboardType="phone-pad"
@@ -3534,6 +3542,7 @@ exports[`The Auth PhoneEntry component should render with a custom smsPromptText
                     <TextInput
                       allowFontScaling={true}
                       autoComplete="tel"
+                      autofocus={true}
                       editable={true}
                       enablesReturnKeyAutomatically={true}
                       keyboardType="phone-pad"
@@ -3917,6 +3926,7 @@ exports[`The Auth PhoneEntry component should render with a value 1`] = `
                     <TextInput
                       allowFontScaling={true}
                       autoComplete="tel"
+                      autofocus={true}
                       editable={true}
                       enablesReturnKeyAutomatically={true}
                       keyboardType="phone-pad"
@@ -4301,6 +4311,7 @@ exports[`The Auth PhoneEntry component should render with an alternate login opt
                     <TextInput
                       allowFontScaling={true}
                       autoComplete="tel"
+                      autofocus={true}
                       editable={true}
                       enablesReturnKeyAutomatically={true}
                       keyboardType="phone-pad"


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

This undoes something we did about a month ago. Originally we took autofocus out with the intention being it was hiding the email and password link. That's because we had too much text on our screen, which has been resolved. About a week ago it was brought up that the mobile sign in should be emphasized more and this does that for us again.

### What design trade-offs/decisions were made?

None.

### How do I test this PR?

Login.

### What automated tests did you write?

None.

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Closes [tag-issues-here]
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._