### PR TITLE
Order Content Channels

### DIFF
--- a/packages/apollos-data-connector-rock/src/content-channels/__tests__/__snapshots__/model.tests.js.snap
+++ b/packages/apollos-data-connector-rock/src/content-channels/__tests__/__snapshots__/model.tests.js.snap
@@ -36,3 +36,31 @@ Object {
   "id": 1,
 }
 `;
+
+exports[`ContentChannelModel gets channels in the given order 1`] = `
+Array [
+  Array [
+    "ContentChannels?%24filter=%28Id%20eq%203%29%20or%20%28Id%20eq%201%29%20or%20%28Id%20eq%208%29",
+    Object {},
+    Object {
+      "cacheOptions": Object {
+        "ttl": 5,
+      },
+    },
+  ],
+]
+`;
+
+exports[`ContentChannelModel gets channels in the given order 2`] = `
+Array [
+  Object {
+    "id": 3,
+  },
+  Object {
+    "id": 1,
+  },
+  Object {
+    "id": 8,
+  },
+]
+`;

--- a/packages/apollos-data-connector-rock/src/content-channels/__tests__/model.tests.js
+++ b/packages/apollos-data-connector-rock/src/content-channels/__tests__/model.tests.js
@@ -8,6 +8,9 @@ ApollosConfig.loadJs({
     API_TOKEN: 'some-rock-token',
     IMAGE_URL: 'https://apollosrock.newspring.cc/GetImage.ashx',
   },
+  ROCK_MAPPINGS: {
+    DISCOVER_CONTENT_CHANNEL_IDS: [3, 1, 8],
+  },
 });
 
 describe('ContentChannelModel', () => {
@@ -18,6 +21,17 @@ describe('ContentChannelModel', () => {
     const dataSource = new ContentChannelDataSource();
     dataSource.get = buildGetMock([{ Id: 1 }, { Id: 2 }], dataSource);
     const result = dataSource.all();
+    expect(result).resolves.toMatchSnapshot();
+    expect(dataSource.get.mock.calls).toMatchSnapshot();
+  });
+
+  it('gets channels in the given order', () => {
+    const dataSource = new ContentChannelDataSource();
+    dataSource.get = buildGetMock(
+      [{ Id: 3 }, { Id: 1 }, { Id: 8 }],
+      dataSource
+    );
+    const result = dataSource.getRootChannels();
     expect(result).resolves.toMatchSnapshot();
     expect(dataSource.get.mock.calls).toMatchSnapshot();
   });

--- a/packages/apollos-data-connector-rock/src/content-channels/data-source.js
+++ b/packages/apollos-data-connector-rock/src/content-channels/data-source.js
@@ -1,6 +1,8 @@
 import RockApolloDataSource from '@apollosproject/rock-apollo-data-source';
 import ApollosConfig from '@apollosproject/config';
 
+import { isEmpty } from 'lodash';
+
 const { ROCK_MAPPINGS } = ApollosConfig;
 
 export default class ContentChannel extends RockApolloDataSource {
@@ -11,8 +13,8 @@ export default class ContentChannel extends RockApolloDataSource {
       .expand('ChildContentChannels')
       .get();
 
-  getRootChannels = () =>
-    this.request()
+  getRootChannels = async () => {
+    const channels = await this.request()
       .filter(
         ROCK_MAPPINGS.DISCOVER_CONTENT_CHANNEL_IDS.map(
           (channelId) => `(Id eq ${channelId})`
@@ -20,6 +22,26 @@ export default class ContentChannel extends RockApolloDataSource {
       )
       .cache({ ttl: 5 })
       .get();
+
+    const sortOrder = ROCK_MAPPINGS.DISCOVER_CONTENT_CHANNEL_IDS;
+    // Sort order could be undefined or have no ids. There's no reason to iterate in this case.
+    if (!sortOrder || isEmpty(sortOrder)) {
+      return channels;
+    }
+    // Setup a result array.
+    const result = [];
+    sortOrder.forEach((configId) => {
+      // Remove the matched element from the channel list.
+      const channel = channels.splice(
+        channels.findIndex(({ id }) => id === configId),
+        1
+      );
+      // And then push it (or nothing) to the end of the result array.
+      result.push(...channel);
+    });
+    // Return results and any left over channels.
+    return [...result, ...channels];
+  };
 
   getFromId = (id) =>
     this.request()


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Implements in apollos core a change already made to Willow Creek. This ensures content is sorted in the order defined in DISCOVER_CONTENT_CHANNEL_IDS. It does so by sorting the channels after fetching them.

I also added an early return in. I checked if DISCOVER_CONTENT_CHANNEL_IDS can be undefined; it can, so I simply returned the order that ROCK gave us, if that's the case.

### What design trade-offs/decisions were made?

### How do I test this PR?

1. Change the order of the IDs in DISCOVER_CONTENT_CHANNEL_IDS located in config.yml
2. Start your packager/sim AFTER this change
3. Navigate to the Discover tab
4. The order of the channels should reflect your changes

### What automated tests did you write?

## SCREENSHOTS

|Normal|Reordered|
|---|---|
|<img width="569" alt="Screen Shot 2019-10-28 at 2 34 54 PM" src="https://user-images.githubusercontent.com/29125070/67708826-33700980-f993-11e9-8be2-9d6c619785cf.png">|<img width="569" alt="Screen Shot 2019-10-28 at 2 23 51 PM" src="https://user-images.githubusercontent.com/29125070/67708818-2ce19200-f993-11e9-9f85-88ca4e72825f.png">|

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Closes #1091 
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
