### PR TITLE
Cache coverImages and don't fetch ContentChannels if not needed to reduce home feed query count

### DIFF
--- a/packages/apollos-data-connector-rock/src/content-items/__tests__/__snapshots__/data-source.tests.js.snap
+++ b/packages/apollos-data-connector-rock/src/content-items/__tests__/__snapshots__/data-source.tests.js.snap
@@ -365,6 +365,29 @@ Array [
 ]
 `;
 
+exports[`ContentItemsModel gets cover image from the cache, when it exists: Get mock calls 1`] = `
+Array [
+  Array [
+    Object {
+      "key": "contentItem:coverImage:123",
+    },
+  ],
+]
+`;
+
+exports[`ContentItemsModel gets cover image from the cache, when it exists: Image result 1`] = `
+Object {
+  "__typename": "ImageMedia",
+  "key": "image",
+  "name": "Image",
+  "sources": Array [
+    Object {
+      "uri": "https://some-domain.com/some/path/to/image.jpg",
+    },
+  ],
+}
+`;
+
 exports[`ContentItemsModel isContentActiveLiveStream returns false if the livestream is innactive 1`] = `Array []`;
 
 exports[`ContentItemsModel isContentActiveLiveStream returns false if the livestream is not the most recent sermon 1`] = `
@@ -575,6 +598,39 @@ Array [
     Object {
       "id": "123-1",
       "text": "that thing is cool",
+    },
+  ],
+]
+`;
+
+exports[`ContentItemsModel stores cover image in the cache, when it exists 1`] = `
+Object {
+  "__typename": "ImageMedia",
+  "key": "image",
+  "name": "Image",
+  "sources": Array [
+    Object {
+      "uri": "https://some-domain.com/some/path/to/image.jpg",
+    },
+  ],
+}
+`;
+
+exports[`ContentItemsModel stores cover image in the cache, when it exists 2`] = `
+Array [
+  Array [
+    Object {
+      "data": Object {
+        "__typename": "ImageMedia",
+        "key": "image",
+        "name": "Image",
+        "sources": Array [
+          Object {
+            "uri": "https://some-domain.com/some/path/to/image.jpg",
+          },
+        ],
+      },
+      "key": "contentItem:coverImage:123",
     },
   ],
 ]

--- a/packages/apollos-data-connector-rock/src/content-items/__tests__/resolvers.tests.js
+++ b/packages/apollos-data-connector-rock/src/content-items/__tests__/resolvers.tests.js
@@ -60,6 +60,16 @@ const Auth = {
   },
 };
 
+class Cache {
+  get = () => Promise.resolve(null);
+
+  set = () => Promise.resolve(null);
+
+  initialize({ context }) {
+    this.context = context;
+  }
+}
+
 const { getSchema, getContext } = createTestHelpers({
   ContentChannel,
   ContentItem,
@@ -76,6 +86,7 @@ const { getSchema, getContext } = createTestHelpers({
   RockConstants,
   Person,
   Auth,
+  Cache: { dataSource: Cache },
 });
 // we import the root-level schema and resolver so we test the entire integration:
 

--- a/packages/apollos-data-connector-rock/src/content-items/data-source.js
+++ b/packages/apollos-data-connector-rock/src/content-items/data-source.js
@@ -1,4 +1,4 @@
-import { get, flatten } from 'lodash';
+import { get } from 'lodash';
 import RockApolloDataSource, {
   parseKeyValueAttribute,
 } from '@apollosproject/rock-apollo-data-source';

--- a/packages/apollos-data-connector-rock/src/content-items/data-source.js
+++ b/packages/apollos-data-connector-rock/src/content-items/data-source.js
@@ -231,38 +231,64 @@ export default class ContentItem extends RockApolloDataSource {
     return mostRecentSermon.id === id;
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  pickBestImage({ images }) {
+    // TODO: there's probably a _much_ more explicit and better way to handle this
+    const squareImage = images.find((image) =>
+      image.key.toLowerCase().includes('square')
+    );
+    console.log({ images });
+    if (squareImage) return { ...squareImage, __typename: 'ImageMedia' };
+    return { ...images[0], __typename: 'ImageMedia' };
+  }
+
   async getCoverImage(root) {
-    const pickBestImage = (images) => {
-      // TODO: there's probably a _much_ more explicit and better way to handle this
-      const squareImage = images.find((image) =>
-        image.key.toLowerCase().includes('square')
-      );
-      if (squareImage) return { ...squareImage, __typename: 'ImageMedia' };
-      return { ...images[0], __typename: 'ImageMedia' };
-    };
+    const { Cache } = this.context.dataSources;
+    const cachedValue = await Cache.get({
+      key: `contentItem:coverImage:${root.id}`,
+    });
 
-    const withSources = (image) => image.sources.length;
-
-    // filter images w/o URLs
-    const ourImages = this.getImages(root).filter(withSources);
-
-    if (ourImages.length) return pickBestImage(ourImages);
-
-    // If no image, check parent for image:
-    const parentItemsCursor = await this.getCursorByChildContentItemId(root.id);
-    if (!parentItemsCursor) return null;
-
-    const parentItems = await parentItemsCursor.get();
-
-    if (parentItems.length) {
-      const parentImages = flatten(parentItems.map(this.getImages));
-      const validParentImages = parentImages.filter(withSources);
-
-      if (validParentImages && validParentImages.length)
-        return pickBestImage(validParentImages);
+    if (cachedValue) {
+      return cachedValue;
     }
 
-    return null;
+    let image = null;
+
+    // filter images w/o URLs
+    const ourImages = this.getImages(root).filter(
+      ({ sources }) => sources.length
+    );
+
+    console.log({ ourImages });
+
+    if (ourImages.length) {
+      image = this.pickBestImage({ images: ourImages });
+    }
+
+    // If no image, check parent for image:
+    if (!image) {
+      // The cursor returns a promise which returns a promisee, hence th edouble eawait.
+      const parentItems = await (await this.getCursorByChildContentItemId(
+        root.id
+      )).get();
+
+      if (parentItems.length) {
+        const validParentImages = parentItems
+          .flatMap(this.getImages)
+          .filter(({ sources }) => sources.length);
+
+        if (validParentImages && validParentImages.length)
+          image = this.pickBestImage({ images: validParentImages });
+      }
+    }
+
+    if (image != null) {
+      Cache.set({ key: `contentItem:coverImage:${root.id}`, data: image });
+    }
+
+    console.log(image);
+
+    return image;
   }
 
   LIVE_CONTENT = () => {
@@ -374,7 +400,10 @@ export default class ContentItem extends RockApolloDataSource {
       .orderBy('StartDateTime', 'desc');
   };
 
-  byUserFeed = () => this.byActive().orderBy('StartDateTime', 'desc');
+  byUserFeed = () =>
+    this.byActive()
+      .orderBy('StartDateTime', 'desc')
+      .expand('ContentChannel');
 
   byActive = () =>
     this.request()

--- a/packages/apollos-data-connector-rock/src/content-items/data-source.js
+++ b/packages/apollos-data-connector-rock/src/content-items/data-source.js
@@ -237,7 +237,6 @@ export default class ContentItem extends RockApolloDataSource {
     const squareImage = images.find((image) =>
       image.key.toLowerCase().includes('square')
     );
-    console.log({ images });
     if (squareImage) return { ...squareImage, __typename: 'ImageMedia' };
     return { ...images[0], __typename: 'ImageMedia' };
   }
@@ -258,8 +257,6 @@ export default class ContentItem extends RockApolloDataSource {
     const ourImages = this.getImages(root).filter(
       ({ sources }) => sources.length
     );
-
-    console.log({ ourImages });
 
     if (ourImages.length) {
       image = this.pickBestImage({ images: ourImages });
@@ -285,8 +282,6 @@ export default class ContentItem extends RockApolloDataSource {
     if (image != null) {
       Cache.set({ key: `contentItem:coverImage:${root.id}`, data: image });
     }
-
-    console.log(image);
 
     return image;
   }

--- a/packages/apollos-data-connector-rock/src/content-items/resolver.js
+++ b/packages/apollos-data-connector-rock/src/content-items/resolver.js
@@ -65,8 +65,11 @@ export const defaultContentItemResolvers = {
       .join(' ');
   },
 
-  parentChannel: ({ contentChannelId }, args, { dataSources }) =>
-    dataSources.ContentChannel.getFromId(contentChannelId),
+  parentChannel: (
+    { contentChannel, contentChannelId },
+    args,
+    { dataSources }
+  ) => contentChannel || dataSources.ContentChannel.getFromId(contentChannelId),
 
   siblingContentItemsConnection: async ({ id }, args, { dataSources }) =>
     dataSources.ContentItem.paginate({


### PR DESCRIPTION
# DESCRIPTION

### What does this PR do, or why is it needed?

We are already doing this on Willow. This PR stores the result of `getCoverImage` in Redis, so that we don't have to fetch the parents for ContentItems that don't have a cover image each and every time we query. 

This PR also eager loads the content channel for a content item, and uses it to return the data present on a ContentChannel, if it exists. This will further eliminate the number of calls we make to rock when loading the home feed. 

Before this PR
![image](https://user-images.githubusercontent.com/1637694/67776097-396af680-fa36-11e9-8f29-21106dfc3dfb.png)

After this PR
![image](https://user-images.githubusercontent.com/1637694/67775793-ce212480-fa35-11e9-8a36-7a64be484940.png)


### What design trade-offs/decisions were made?
n/a

### How do I test this PR?

1. Load the home feed in the app in master, note the number of queries running.
2. Load the home feed in this PR. It should look the same, but you should see a significantly reduced number of queries ran, especially after the second request. 

### What automated tests did you write?

Tests over new cache functionality. 

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [x] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
