### PR TITLE
Removes like-count from content tile

### DIFF
--- a/packages/apolloschurchapp/src/content-feed/__snapshots__/content-feed.tests.js.snap
+++ b/packages/apolloschurchapp/src/content-feed/__snapshots__/content-feed.tests.js.snap
@@ -38,7 +38,6 @@ exports[`content feed query component renders a feedview after successful query 
           "hyphenatedTitle": "Mea Animal Aperiam Ornatus Eu",
           "id": "UniversalContentItem:d57994350b9d213866b24dea3a97433d",
           "isLiked": false,
-          "likedCount": 0,
           "parentChannel": Object {
             "__typename": "ContentChannel",
             "id": "ContentChannel:4f68015ba18662a7409d1219a4ce013e",
@@ -56,7 +55,6 @@ exports[`content feed query component renders a feedview after successful query 
           "hyphenatedTitle": "Probo Senserit Id Mea, Ut Sed Malis Postea,",
           "id": "UniversalContentItem:b36e55d803443431e96bb4b5068147ec",
           "isLiked": false,
-          "likedCount": 0,
           "parentChannel": Object {
             "__typename": "ContentChannel",
             "id": "ContentChannel:4f68015ba18662a7409d1219a4ce013e",

--- a/packages/apolloschurchapp/src/content-single/getContentItem.js
+++ b/packages/apolloschurchapp/src/content-single/getContentItem.js
@@ -5,7 +5,6 @@ export const CONTENT_ITEM_FRAGMENT = gql`
     id
     title
     isLiked
-    likedCount
     summary
     coverImage {
       name

--- a/packages/apolloschurchapp/src/tabs/connect/LikedContentList/__snapshots__/LikedContentList.tests.js.snap
+++ b/packages/apolloschurchapp/src/tabs/connect/LikedContentList/__snapshots__/LikedContentList.tests.js.snap
@@ -57,7 +57,6 @@ fragment contentItemFragment on ContentItem {
   id
   title
   isLiked
-  likedCount
   summary
   coverImage {
     name
@@ -307,7 +306,6 @@ fragment contentItemFragment on ContentItem {
   id
   title
   isLiked
-  likedCount
   summary
   coverImage {
     name

--- a/packages/apolloschurchapp/src/tabs/connect/RecentlyLikedTileFeed/__snapshots__/RecentlyLikedTileFeedConnected.tests.js.snap
+++ b/packages/apolloschurchapp/src/tabs/connect/RecentlyLikedTileFeed/__snapshots__/RecentlyLikedTileFeedConnected.tests.js.snap
@@ -107,7 +107,6 @@ exports[`RecentlyLikedTileFeedConnected renders a RecentlyLikedTileFeedConnected
           "hyphenatedTitle": "Mea Animal Aperiam Ornatus Eu",
           "id": "UniversalContentItem:d57994350b9d213866b24dea3a97433d",
           "isLiked": false,
-          "likedCount": 0,
           "parentChannel": Object {
             "__typename": "ContentChannel",
             "id": "ContentChannel:4f68015ba18662a7409d1219a4ce013e",
@@ -125,7 +124,6 @@ exports[`RecentlyLikedTileFeedConnected renders a RecentlyLikedTileFeedConnected
           "hyphenatedTitle": "Probo Senserit Id Mea, Ut Sed Malis Postea,",
           "id": "UniversalContentItem:b36e55d803443431e96bb4b5068147ec",
           "isLiked": false,
-          "likedCount": 0,
           "parentChannel": Object {
             "__typename": "ContentChannel",
             "id": "ContentChannel:4f68015ba18662a7409d1219a4ce013e",
@@ -863,7 +861,6 @@ exports[`RecentlyLikedTileFeedConnected renders nothing if no liked content 1`] 
           "hyphenatedTitle": "Mea Animal Aperiam Ornatus Eu",
           "id": "UniversalContentItem:d57994350b9d213866b24dea3a97433d",
           "isLiked": false,
-          "likedCount": 0,
           "parentChannel": Object {
             "__typename": "ContentChannel",
             "id": "ContentChannel:4f68015ba18662a7409d1219a4ce013e",
@@ -881,7 +878,6 @@ exports[`RecentlyLikedTileFeedConnected renders nothing if no liked content 1`] 
           "hyphenatedTitle": "Probo Senserit Id Mea, Ut Sed Malis Postea,",
           "id": "UniversalContentItem:b36e55d803443431e96bb4b5068147ec",
           "isLiked": false,
-          "likedCount": 0,
           "parentChannel": Object {
             "__typename": "ContentChannel",
             "id": "ContentChannel:4f68015ba18662a7409d1219a4ce013e",

--- a/packages/apolloschurchapp/src/tabs/discover/DiscoverFeed/__snapshots__/DiscoverFeed.tests.js.snap
+++ b/packages/apolloschurchapp/src/tabs/discover/DiscoverFeed/__snapshots__/DiscoverFeed.tests.js.snap
@@ -86,7 +86,6 @@ exports[`The DiscoverFeed component should render 1`] = `
                           "hyphenatedTitle": "Anderson Family Cookout!",
                           "id": "UniversalContentItem:00bb7b364911281c97fc50f2a0d17b11",
                           "isLiked": false,
-                          "likedCount": 0,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:965b6e6d7046a885bea4e300b5c0400d",
@@ -116,7 +115,6 @@ exports[`The DiscoverFeed component should render 1`] = `
                           "hyphenatedTitle": "Robert Madu is Coming to Christ Fellowship",
                           "id": "UniversalContentItem:7db601b238aa4345a818654300f83dd2",
                           "isLiked": false,
-                          "likedCount": 5,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:965b6e6d7046a885bea4e300b5c0400d",
@@ -146,7 +144,6 @@ exports[`The DiscoverFeed component should render 1`] = `
                           "hyphenatedTitle": "Guys Night!",
                           "id": "UniversalContentItem:296373ecb53580855cadffa0375ebe18",
                           "isLiked": false,
-                          "likedCount": 0,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:965b6e6d7046a885bea4e300b5c0400d",
@@ -177,7 +174,6 @@ exports[`The DiscoverFeed component should render 1`] = `
                           "hyphenatedTitle": "Test Article",
                           "id": "UniversalContentItem:604a4a763a5fc0edfe386684ca6b3515",
                           "isLiked": false,
-                          "likedCount": 0,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:4f68015ba18662a7409d1219a4ce013e",
@@ -198,7 +194,6 @@ exports[`The DiscoverFeed component should render 1`] = `
                           "hyphenatedTitle": "10 ways to refresh your spirit every day",
                           "id": "UniversalContentItem:c495ff18cd998ed516a798b6218907cd",
                           "isLiked": false,
-                          "likedCount": 2,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:4f68015ba18662a7409d1219a4ce013e",
@@ -219,7 +214,6 @@ exports[`The DiscoverFeed component should render 1`] = `
                           "hyphenatedTitle": "Live for Freedom Toolkit",
                           "id": "UniversalContentItem:95ff79f60a028b1b506aaeedf8b4c6ae",
                           "isLiked": false,
-                          "likedCount": 1,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:4f68015ba18662a7409d1219a4ce013e",
@@ -260,7 +254,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                           "hyphenatedTitle": "The New Weekend Experience",
                           "id": "ContentSeriesContentItem:6d8dc8e4bad017f815ae0cac8bf692bb",
                           "isLiked": false,
-                          "likedCount": 1,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:a0f64573eabf00a607bec911794d50fb",
@@ -299,7 +292,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                           "hyphenatedTitle": "Gathering",
                           "id": "ContentSeriesContentItem:08449058d438ebeaffe9adb7a8e633cc",
                           "isLiked": false,
-                          "likedCount": 0,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:a0f64573eabf00a607bec911794d50fb",
@@ -338,7 +330,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                           "hyphenatedTitle": "Gauntlet 2018",
                           "id": "ContentSeriesContentItem:b74c2d295a0cf1340232ffa8be856c00",
                           "isLiked": false,
-                          "likedCount": 0,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:a0f64573eabf00a607bec911794d50fb",
@@ -387,7 +378,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                           "hyphenatedTitle": "Jeremiah: A 33-Day Devotional",
                           "id": "ContentSeriesContentItem:b085ec27d53006e9e6b95f3ac57da581",
                           "isLiked": true,
-                          "likedCount": 6,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:7fba1b1ee253e0fd5f0795b4b8b1175e",
@@ -422,7 +412,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                           "hyphenatedTitle": "How To Be A Better Leader: A 7-Day Devotional",
                           "id": "ContentSeriesContentItem:71bfdac0b98ea1b72a63ff4ea64e3c5a",
                           "isLiked": false,
-                          "likedCount": 0,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:7fba1b1ee253e0fd5f0795b4b8b1175e",
@@ -457,7 +446,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                           "hyphenatedTitle": "2 Thessalonians: A 5-Day Devotional",
                           "id": "ContentSeriesContentItem:44fd3b82373ea8f197bd1e1e77c4bed0",
                           "isLiked": false,
-                          "likedCount": 0,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:7fba1b1ee253e0fd5f0795b4b8b1175e",
@@ -502,7 +490,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                           "hyphenatedTitle": "The surprising journey that changed me and my dad",
                           "id": "UniversalContentItem:cf8fa657f23af88a2d63f7e4a2237db8",
                           "isLiked": false,
-                          "likedCount": 6,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:be7381e9c2fea9f41504cd98d4b14321",
@@ -532,7 +519,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                           "hyphenatedTitle": "When I lost hope, my church family had my back",
                           "id": "UniversalContentItem:2e17f5a66407d114ab9f2392b03ebccd",
                           "isLiked": true,
-                          "likedCount": 5,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:be7381e9c2fea9f41504cd98d4b14321",
@@ -562,7 +548,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                           "hyphenatedTitle": "A Place to Worship Free of Fear",
                           "id": "UniversalContentItem:ae8ec75906ba7437c49ad2534b5024db",
                           "isLiked": false,
-                          "likedCount": 1,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:be7381e9c2fea9f41504cd98d4b14321",
@@ -730,7 +715,6 @@ Our son Cameron began attending Willow Creek Special Friends in 2015.",
                         "hyphenatedTitle": "Anderson Family Cookout!",
                         "id": "UniversalContentItem:00bb7b364911281c97fc50f2a0d17b11",
                         "isLiked": false,
-                        "likedCount": 0,
                         "parentChannel": Object {
                           "__typename": "ContentChannel",
                           "id": "ContentChannel:965b6e6d7046a885bea4e300b5c0400d",
@@ -757,7 +741,6 @@ Our son Cameron began attending Willow Creek Special Friends in 2015.",
                         "hyphenatedTitle": "Robert Madu is Coming to Christ Fellowship",
                         "id": "UniversalContentItem:7db601b238aa4345a818654300f83dd2",
                         "isLiked": false,
-                        "likedCount": 5,
                         "parentChannel": Object {
                           "__typename": "ContentChannel",
                           "id": "ContentChannel:965b6e6d7046a885bea4e300b5c0400d",
@@ -784,7 +767,6 @@ Our son Cameron began attending Willow Creek Special Friends in 2015.",
                         "hyphenatedTitle": "Guys Night!",
                         "id": "UniversalContentItem:296373ecb53580855cadffa0375ebe18",
                         "isLiked": false,
-                        "likedCount": 0,
                         "parentChannel": Object {
                           "__typename": "ContentChannel",
                           "id": "ContentChannel:965b6e6d7046a885bea4e300b5c0400d",
@@ -1883,7 +1865,6 @@ Our son Cameron began attending Willow Creek Special Friends in 2015.",
                         "hyphenatedTitle": "Test Article",
                         "id": "UniversalContentItem:604a4a763a5fc0edfe386684ca6b3515",
                         "isLiked": false,
-                        "likedCount": 0,
                         "parentChannel": Object {
                           "__typename": "ContentChannel",
                           "id": "ContentChannel:4f68015ba18662a7409d1219a4ce013e",
@@ -1901,7 +1882,6 @@ Our son Cameron began attending Willow Creek Special Friends in 2015.",
                         "hyphenatedTitle": "10 ways to refresh your spirit every day",
                         "id": "UniversalContentItem:c495ff18cd998ed516a798b6218907cd",
                         "isLiked": false,
-                        "likedCount": 2,
                         "parentChannel": Object {
                           "__typename": "ContentChannel",
                           "id": "ContentChannel:4f68015ba18662a7409d1219a4ce013e",
@@ -1919,7 +1899,6 @@ Our son Cameron began attending Willow Creek Special Friends in 2015.",
                         "hyphenatedTitle": "Live for Freedom Toolkit",
                         "id": "UniversalContentItem:95ff79f60a028b1b506aaeedf8b4c6ae",
                         "isLiked": false,
-                        "likedCount": 1,
                         "parentChannel": Object {
                           "__typename": "ContentChannel",
                           "id": "ContentChannel:4f68015ba18662a7409d1219a4ce013e",
@@ -2945,7 +2924,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                         "hyphenatedTitle": "The New Weekend Experience",
                         "id": "ContentSeriesContentItem:6d8dc8e4bad017f815ae0cac8bf692bb",
                         "isLiked": false,
-                        "likedCount": 1,
                         "parentChannel": Object {
                           "__typename": "ContentChannel",
                           "id": "ContentChannel:a0f64573eabf00a607bec911794d50fb",
@@ -2981,7 +2959,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                         "hyphenatedTitle": "Gathering",
                         "id": "ContentSeriesContentItem:08449058d438ebeaffe9adb7a8e633cc",
                         "isLiked": false,
-                        "likedCount": 0,
                         "parentChannel": Object {
                           "__typename": "ContentChannel",
                           "id": "ContentChannel:a0f64573eabf00a607bec911794d50fb",
@@ -3017,7 +2994,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                         "hyphenatedTitle": "Gauntlet 2018",
                         "id": "ContentSeriesContentItem:b74c2d295a0cf1340232ffa8be856c00",
                         "isLiked": false,
-                        "likedCount": 0,
                         "parentChannel": Object {
                           "__typename": "ContentChannel",
                           "id": "ContentChannel:a0f64573eabf00a607bec911794d50fb",
@@ -4167,7 +4143,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                         "hyphenatedTitle": "Jeremiah: A 33-Day Devotional",
                         "id": "ContentSeriesContentItem:b085ec27d53006e9e6b95f3ac57da581",
                         "isLiked": true,
-                        "likedCount": 6,
                         "parentChannel": Object {
                           "__typename": "ContentChannel",
                           "id": "ContentChannel:7fba1b1ee253e0fd5f0795b4b8b1175e",
@@ -4199,7 +4174,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                         "hyphenatedTitle": "How To Be A Better Leader: A 7-Day Devotional",
                         "id": "ContentSeriesContentItem:71bfdac0b98ea1b72a63ff4ea64e3c5a",
                         "isLiked": false,
-                        "likedCount": 0,
                         "parentChannel": Object {
                           "__typename": "ContentChannel",
                           "id": "ContentChannel:7fba1b1ee253e0fd5f0795b4b8b1175e",
@@ -4231,7 +4205,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                         "hyphenatedTitle": "2 Thessalonians: A 5-Day Devotional",
                         "id": "ContentSeriesContentItem:44fd3b82373ea8f197bd1e1e77c4bed0",
                         "isLiked": false,
-                        "likedCount": 0,
                         "parentChannel": Object {
                           "__typename": "ContentChannel",
                           "id": "ContentChannel:7fba1b1ee253e0fd5f0795b4b8b1175e",
@@ -5377,7 +5350,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                         "hyphenatedTitle": "The surprising journey that changed me and my dad",
                         "id": "UniversalContentItem:cf8fa657f23af88a2d63f7e4a2237db8",
                         "isLiked": false,
-                        "likedCount": 6,
                         "parentChannel": Object {
                           "__typename": "ContentChannel",
                           "id": "ContentChannel:be7381e9c2fea9f41504cd98d4b14321",
@@ -5404,7 +5376,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                         "hyphenatedTitle": "When I lost hope, my church family had my back",
                         "id": "UniversalContentItem:2e17f5a66407d114ab9f2392b03ebccd",
                         "isLiked": true,
-                        "likedCount": 5,
                         "parentChannel": Object {
                           "__typename": "ContentChannel",
                           "id": "ContentChannel:be7381e9c2fea9f41504cd98d4b14321",
@@ -5431,7 +5402,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                         "hyphenatedTitle": "A Place to Worship Free of Fear",
                         "id": "UniversalContentItem:ae8ec75906ba7437c49ad2534b5024db",
                         "isLiked": false,
-                        "likedCount": 1,
                         "parentChannel": Object {
                           "__typename": "ContentChannel",
                           "id": "ContentChannel:be7381e9c2fea9f41504cd98d4b14321",

--- a/packages/apolloschurchapp/src/tabs/discover/SearchFeed/__snapshots__/SearchFeed.tests.js.snap
+++ b/packages/apolloschurchapp/src/tabs/discover/SearchFeed/__snapshots__/SearchFeed.tests.js.snap
@@ -81,7 +81,6 @@ exports[`The SearchFeed component should render 1`] = `
                   "hyphenatedTitle": "-",
                   "id": "DevotionalContentItem:561dfb7dbd8a5c093fd8385c7edaadbc",
                   "isLiked": false,
-                  "likedCount": 0,
                   "parentChannel": Object {
                     "__typename": "ContentChannel",
                     "id": "ContentChannel:559b23fd0aa90e81b1c023e72e230fa1",
@@ -104,7 +103,6 @@ exports[`The SearchFeed component should render 1`] = `
                   "hyphenatedTitle": "-",
                   "id": "UniversalContentItem:95ff79f60a028b1b506aaeedf8b4c6ae",
                   "isLiked": false,
-                  "likedCount": 1,
                   "parentChannel": Object {
                     "__typename": "ContentChannel",
                     "id": "ContentChannel:4f68015ba18662a7409d1219a4ce013e",
@@ -132,7 +130,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                   "hyphenatedTitle": "-",
                   "id": "UniversalContentItem:895738f70482712adb3ab45a08c30456",
                   "isLiked": false,
-                  "likedCount": 0,
                   "parentChannel": Object {
                     "__typename": "ContentChannel",
                     "id": "ContentChannel:4f68015ba18662a7409d1219a4ce013e",
@@ -159,7 +156,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                   "hyphenatedTitle": "-",
                   "id": "UniversalContentItem:296373ecb53580855cadffa0375ebe18",
                   "isLiked": false,
-                  "likedCount": 0,
                   "parentChannel": Object {
                     "__typename": "ContentChannel",
                     "id": "ContentChannel:965b6e6d7046a885bea4e300b5c0400d",
@@ -177,7 +173,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                   "hyphenatedTitle": "-",
                   "id": "UniversalContentItem:c495ff18cd998ed516a798b6218907cd",
                   "isLiked": false,
-                  "likedCount": 2,
                   "parentChannel": Object {
                     "__typename": "ContentChannel",
                     "id": "ContentChannel:4f68015ba18662a7409d1219a4ce013e",
@@ -204,7 +199,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                   "hyphenatedTitle": "-",
                   "id": "DevotionalContentItem:4dd74ceca9e09b5276e93cbf53821bd6",
                   "isLiked": false,
-                  "likedCount": 0,
                   "parentChannel": Object {
                     "__typename": "ContentChannel",
                     "id": "ContentChannel:559b23fd0aa90e81b1c023e72e230fa1",

--- a/packages/apolloschurchapp/src/tabs/discover/__snapshots__/discover.tests.js.snap
+++ b/packages/apolloschurchapp/src/tabs/discover/__snapshots__/discover.tests.js.snap
@@ -502,7 +502,6 @@ exports[`The Discover tab component Should retrieve the Content Channel Feeds 1`
                             "hyphenatedTitle": "Anderson Family Cookout!",
                             "id": "UniversalContentItem:00bb7b364911281c97fc50f2a0d17b11",
                             "isLiked": false,
-                            "likedCount": 0,
                             "parentChannel": Object {
                               "__typename": "ContentChannel",
                               "id": "ContentChannel:965b6e6d7046a885bea4e300b5c0400d",
@@ -532,7 +531,6 @@ exports[`The Discover tab component Should retrieve the Content Channel Feeds 1`
                             "hyphenatedTitle": "Robert Madu is Coming to Christ Fellowship",
                             "id": "UniversalContentItem:7db601b238aa4345a818654300f83dd2",
                             "isLiked": false,
-                            "likedCount": 5,
                             "parentChannel": Object {
                               "__typename": "ContentChannel",
                               "id": "ContentChannel:965b6e6d7046a885bea4e300b5c0400d",
@@ -562,7 +560,6 @@ exports[`The Discover tab component Should retrieve the Content Channel Feeds 1`
                             "hyphenatedTitle": "Guys Night!",
                             "id": "UniversalContentItem:296373ecb53580855cadffa0375ebe18",
                             "isLiked": false,
-                            "likedCount": 0,
                             "parentChannel": Object {
                               "__typename": "ContentChannel",
                               "id": "ContentChannel:965b6e6d7046a885bea4e300b5c0400d",
@@ -593,7 +590,6 @@ exports[`The Discover tab component Should retrieve the Content Channel Feeds 1`
                             "hyphenatedTitle": "Test Article",
                             "id": "UniversalContentItem:604a4a763a5fc0edfe386684ca6b3515",
                             "isLiked": false,
-                            "likedCount": 0,
                             "parentChannel": Object {
                               "__typename": "ContentChannel",
                               "id": "ContentChannel:4f68015ba18662a7409d1219a4ce013e",
@@ -614,7 +610,6 @@ exports[`The Discover tab component Should retrieve the Content Channel Feeds 1`
                             "hyphenatedTitle": "10 ways to refresh your spirit every day",
                             "id": "UniversalContentItem:c495ff18cd998ed516a798b6218907cd",
                             "isLiked": false,
-                            "likedCount": 2,
                             "parentChannel": Object {
                               "__typename": "ContentChannel",
                               "id": "ContentChannel:4f68015ba18662a7409d1219a4ce013e",
@@ -635,7 +630,6 @@ exports[`The Discover tab component Should retrieve the Content Channel Feeds 1`
                             "hyphenatedTitle": "Live for Freedom Toolkit",
                             "id": "UniversalContentItem:95ff79f60a028b1b506aaeedf8b4c6ae",
                             "isLiked": false,
-                            "likedCount": 1,
                             "parentChannel": Object {
                               "__typename": "ContentChannel",
                               "id": "ContentChannel:4f68015ba18662a7409d1219a4ce013e",
@@ -676,7 +670,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                             "hyphenatedTitle": "The New Weekend Experience",
                             "id": "ContentSeriesContentItem:6d8dc8e4bad017f815ae0cac8bf692bb",
                             "isLiked": false,
-                            "likedCount": 1,
                             "parentChannel": Object {
                               "__typename": "ContentChannel",
                               "id": "ContentChannel:a0f64573eabf00a607bec911794d50fb",
@@ -715,7 +708,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                             "hyphenatedTitle": "Gathering",
                             "id": "ContentSeriesContentItem:08449058d438ebeaffe9adb7a8e633cc",
                             "isLiked": false,
-                            "likedCount": 0,
                             "parentChannel": Object {
                               "__typename": "ContentChannel",
                               "id": "ContentChannel:a0f64573eabf00a607bec911794d50fb",
@@ -754,7 +746,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                             "hyphenatedTitle": "Gauntlet 2018",
                             "id": "ContentSeriesContentItem:b74c2d295a0cf1340232ffa8be856c00",
                             "isLiked": false,
-                            "likedCount": 0,
                             "parentChannel": Object {
                               "__typename": "ContentChannel",
                               "id": "ContentChannel:a0f64573eabf00a607bec911794d50fb",
@@ -803,7 +794,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                             "hyphenatedTitle": "Jeremiah: A 33-Day Devotional",
                             "id": "ContentSeriesContentItem:b085ec27d53006e9e6b95f3ac57da581",
                             "isLiked": true,
-                            "likedCount": 6,
                             "parentChannel": Object {
                               "__typename": "ContentChannel",
                               "id": "ContentChannel:7fba1b1ee253e0fd5f0795b4b8b1175e",
@@ -838,7 +828,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                             "hyphenatedTitle": "How To Be A Better Leader: A 7-Day Devotional",
                             "id": "ContentSeriesContentItem:71bfdac0b98ea1b72a63ff4ea64e3c5a",
                             "isLiked": false,
-                            "likedCount": 0,
                             "parentChannel": Object {
                               "__typename": "ContentChannel",
                               "id": "ContentChannel:7fba1b1ee253e0fd5f0795b4b8b1175e",
@@ -873,7 +862,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                             "hyphenatedTitle": "2 Thessalonians: A 5-Day Devotional",
                             "id": "ContentSeriesContentItem:44fd3b82373ea8f197bd1e1e77c4bed0",
                             "isLiked": false,
-                            "likedCount": 0,
                             "parentChannel": Object {
                               "__typename": "ContentChannel",
                               "id": "ContentChannel:7fba1b1ee253e0fd5f0795b4b8b1175e",
@@ -918,7 +906,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                             "hyphenatedTitle": "The surprising journey that changed me and my dad",
                             "id": "UniversalContentItem:cf8fa657f23af88a2d63f7e4a2237db8",
                             "isLiked": false,
-                            "likedCount": 6,
                             "parentChannel": Object {
                               "__typename": "ContentChannel",
                               "id": "ContentChannel:be7381e9c2fea9f41504cd98d4b14321",
@@ -948,7 +935,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                             "hyphenatedTitle": "When I lost hope, my church family had my back",
                             "id": "UniversalContentItem:2e17f5a66407d114ab9f2392b03ebccd",
                             "isLiked": true,
-                            "likedCount": 5,
                             "parentChannel": Object {
                               "__typename": "ContentChannel",
                               "id": "ContentChannel:be7381e9c2fea9f41504cd98d4b14321",
@@ -978,7 +964,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                             "hyphenatedTitle": "A Place to Worship Free of Fear",
                             "id": "UniversalContentItem:ae8ec75906ba7437c49ad2534b5024db",
                             "isLiked": false,
-                            "likedCount": 1,
                             "parentChannel": Object {
                               "__typename": "ContentChannel",
                               "id": "ContentChannel:be7381e9c2fea9f41504cd98d4b14321",
@@ -1146,7 +1131,6 @@ Our son Cameron began attending Willow Creek Special Friends in 2015.",
                           "hyphenatedTitle": "Anderson Family Cookout!",
                           "id": "UniversalContentItem:00bb7b364911281c97fc50f2a0d17b11",
                           "isLiked": false,
-                          "likedCount": 0,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:965b6e6d7046a885bea4e300b5c0400d",
@@ -1173,7 +1157,6 @@ Our son Cameron began attending Willow Creek Special Friends in 2015.",
                           "hyphenatedTitle": "Robert Madu is Coming to Christ Fellowship",
                           "id": "UniversalContentItem:7db601b238aa4345a818654300f83dd2",
                           "isLiked": false,
-                          "likedCount": 5,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:965b6e6d7046a885bea4e300b5c0400d",
@@ -1200,7 +1183,6 @@ Our son Cameron began attending Willow Creek Special Friends in 2015.",
                           "hyphenatedTitle": "Guys Night!",
                           "id": "UniversalContentItem:296373ecb53580855cadffa0375ebe18",
                           "isLiked": false,
-                          "likedCount": 0,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:965b6e6d7046a885bea4e300b5c0400d",
@@ -2299,7 +2281,6 @@ Our son Cameron began attending Willow Creek Special Friends in 2015.",
                           "hyphenatedTitle": "Test Article",
                           "id": "UniversalContentItem:604a4a763a5fc0edfe386684ca6b3515",
                           "isLiked": false,
-                          "likedCount": 0,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:4f68015ba18662a7409d1219a4ce013e",
@@ -2317,7 +2298,6 @@ Our son Cameron began attending Willow Creek Special Friends in 2015.",
                           "hyphenatedTitle": "10 ways to refresh your spirit every day",
                           "id": "UniversalContentItem:c495ff18cd998ed516a798b6218907cd",
                           "isLiked": false,
-                          "likedCount": 2,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:4f68015ba18662a7409d1219a4ce013e",
@@ -2335,7 +2315,6 @@ Our son Cameron began attending Willow Creek Special Friends in 2015.",
                           "hyphenatedTitle": "Live for Freedom Toolkit",
                           "id": "UniversalContentItem:95ff79f60a028b1b506aaeedf8b4c6ae",
                           "isLiked": false,
-                          "likedCount": 1,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:4f68015ba18662a7409d1219a4ce013e",
@@ -3361,7 +3340,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                           "hyphenatedTitle": "The New Weekend Experience",
                           "id": "ContentSeriesContentItem:6d8dc8e4bad017f815ae0cac8bf692bb",
                           "isLiked": false,
-                          "likedCount": 1,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:a0f64573eabf00a607bec911794d50fb",
@@ -3397,7 +3375,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                           "hyphenatedTitle": "Gathering",
                           "id": "ContentSeriesContentItem:08449058d438ebeaffe9adb7a8e633cc",
                           "isLiked": false,
-                          "likedCount": 0,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:a0f64573eabf00a607bec911794d50fb",
@@ -3433,7 +3410,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                           "hyphenatedTitle": "Gauntlet 2018",
                           "id": "ContentSeriesContentItem:b74c2d295a0cf1340232ffa8be856c00",
                           "isLiked": false,
-                          "likedCount": 0,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:a0f64573eabf00a607bec911794d50fb",
@@ -4583,7 +4559,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                           "hyphenatedTitle": "Jeremiah: A 33-Day Devotional",
                           "id": "ContentSeriesContentItem:b085ec27d53006e9e6b95f3ac57da581",
                           "isLiked": true,
-                          "likedCount": 6,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:7fba1b1ee253e0fd5f0795b4b8b1175e",
@@ -4615,7 +4590,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                           "hyphenatedTitle": "How To Be A Better Leader: A 7-Day Devotional",
                           "id": "ContentSeriesContentItem:71bfdac0b98ea1b72a63ff4ea64e3c5a",
                           "isLiked": false,
-                          "likedCount": 0,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:7fba1b1ee253e0fd5f0795b4b8b1175e",
@@ -4647,7 +4621,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                           "hyphenatedTitle": "2 Thessalonians: A 5-Day Devotional",
                           "id": "ContentSeriesContentItem:44fd3b82373ea8f197bd1e1e77c4bed0",
                           "isLiked": false,
-                          "likedCount": 0,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:7fba1b1ee253e0fd5f0795b4b8b1175e",
@@ -5793,7 +5766,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                           "hyphenatedTitle": "The surprising journey that changed me and my dad",
                           "id": "UniversalContentItem:cf8fa657f23af88a2d63f7e4a2237db8",
                           "isLiked": false,
-                          "likedCount": 6,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:be7381e9c2fea9f41504cd98d4b14321",
@@ -5820,7 +5792,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                           "hyphenatedTitle": "When I lost hope, my church family had my back",
                           "id": "UniversalContentItem:2e17f5a66407d114ab9f2392b03ebccd",
                           "isLiked": true,
-                          "likedCount": 5,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:be7381e9c2fea9f41504cd98d4b14321",
@@ -5847,7 +5818,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                           "hyphenatedTitle": "A Place to Worship Free of Fear",
                           "id": "UniversalContentItem:ae8ec75906ba7437c49ad2534b5024db",
                           "isLiked": false,
-                          "likedCount": 1,
                           "parentChannel": Object {
                             "__typename": "ContentChannel",
                             "id": "ContentChannel:be7381e9c2fea9f41504cd98d4b14321",

--- a/packages/apolloschurchapp/src/tabs/home/__snapshots__/home.tests.js.snap
+++ b/packages/apolloschurchapp/src/tabs/home/__snapshots__/home.tests.js.snap
@@ -227,17 +227,6 @@ exports[`User Home Feed Query should return correct query results 1`] = `
                           "kind": "Field",
                           "name": Object {
                             "kind": "Name",
-                            "value": "likedCount",
-                          },
-                          "selectionSet": undefined,
-                        },
-                        Object {
-                          "alias": undefined,
-                          "arguments": Array [],
-                          "directives": Array [],
-                          "kind": "Field",
-                          "name": Object {
-                            "kind": "Name",
                             "value": "summary",
                           },
                           "selectionSet": undefined,
@@ -1094,7 +1083,7 @@ exports[`User Home Feed Query should return correct query results 1`] = `
                 ],
                 "kind": "Document",
                 "loc": Object {
-                  "end": 1779,
+                  "end": 1764,
                   "start": 0,
                 },
               }


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

We don't use the like count in the content tile anymore. We should remove it from the query. 

### What design trade-offs/decisions were made?

n/a

### How do I test this PR?

1. Open the home feed.
2. Everything should render without issues. 

### What automated tests did you write?

n/a

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [x] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
