### PR TITLE
Move Picture Loading Indicator

### DIFF
--- a/packages/apollos-ui-kit/src/Avatar/index.js
+++ b/packages/apollos-ui-kit/src/Avatar/index.js
@@ -63,6 +63,17 @@ const ButtonIconPositioner = styled({
   right: 0,
 })(View);
 
+const LoadingSpinnerContainer = styled({
+  backgroundColor: 'white',
+  // The following three measurements are used to match those of the ButtonIcon container
+  width: 43,
+  height: 43,
+  padding: 9.6,
+  borderRadius: 50,
+  justifyContent: 'center',
+  alignItems: 'center',
+})(View);
+
 const Avatar = enhance(
   ({
     themeSize,
@@ -75,7 +86,6 @@ const Avatar = enhance(
     ...imageProps
   }) => (
     <Container style={containerStyle} themeSize={themeSize}>
-      {isLoading ? <LoadingIcon /> : null}
       {source && source.uri ? (
         <Image
           source={source}
@@ -88,13 +98,19 @@ const Avatar = enhance(
       )}
       {buttonIcon ? (
         <ButtonIconPositioner>
-          <StyledButtonIcon
-            onPress={onPressIcon}
-            name={buttonIcon}
-            size={themeSize / 5}
-            fill={iconFill}
-            TouchableComponent={TouchableScale}
-          />
+          {isLoading ? (
+            <LoadingSpinnerContainer>
+              <ActivityIndicator size={themeSize / 5} />
+            </LoadingSpinnerContainer>
+          ) : (
+            <StyledButtonIcon
+              onPress={onPressIcon}
+              name={buttonIcon}
+              size={themeSize / 5}
+              fill={iconFill}
+              TouchableComponent={TouchableScale}
+            />
+          )}
         </ButtonIconPositioner>
       ) : null}
     </Container>

--- a/packages/apollos-ui-kit/src/Avatar/index.js
+++ b/packages/apollos-ui-kit/src/Avatar/index.js
@@ -28,13 +28,6 @@ const Container = styled(
   'Avatar'
 )(View);
 
-const LoadingIcon = compose(
-  withTheme(({ theme: { colors } = {} }) => ({ color: colors.white })),
-  styled({
-    zIndex: 1,
-  })
-)(ActivityIndicator);
-
 const PlaceholderIcon = compose(
   withTheme(({ theme: { colors } = {} }) => ({
     fill: colors.background.inactive,
@@ -63,7 +56,7 @@ const ButtonIconPositioner = styled({
   right: 0,
 })(View);
 
-const LoadingSpinnerContainer = styled({
+const LoadingSpinnerContainer = styled(({ theme }) => ({
   backgroundColor: 'white',
   // The following three measurements are used to match those of the ButtonIcon container
   width: 43,
@@ -72,7 +65,8 @@ const LoadingSpinnerContainer = styled({
   borderRadius: 50,
   justifyContent: 'center',
   alignItems: 'center',
-})(View);
+  ...Platform.select(theme.shadows.default),
+}))(View);
 
 const Avatar = enhance(
   ({


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?'

Moves the loading indicator for uploading a picture to what is normally the button to change a user's image (obviously, while the loading indicator is there, it is not a button). We did this because the loading indicator was very difficult (read: impossible) to see when placed overtop of the placeholder icon or white pictures. Moving it to the new location means it's visible regardless of the current status of the profile image.

### What design trade-offs/decisions were made?

See above.

### How do I test this PR?

1. Navigate to the settings screen
2. Change your profile picture
3. The loading spinner should replace the camera icon until the image has finished loading

### What automated tests did you write?

## SCREENSHOTS

<img width="569" alt="Screen Shot 2019-10-30 at 3 08 17 PM" src="https://user-images.githubusercontent.com/29125070/67895834-98616600-fb31-11e9-905a-2345345ac9d1.png">


## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
