### PR TITLE
Prefetch the Current User

### DIFF
--- a/packages/apollos-data-connector-rock/src/auth/data-source.js
+++ b/packages/apollos-data-connector-rock/src/auth/data-source.js
@@ -12,6 +12,11 @@ export default class AuthDataSource extends RockApolloDataSource {
 
   userToken = null;
 
+  initialize(config) {
+    super.initialize(config);
+    this.getCurrentPerson();
+  }
+
   getCurrentPerson = async ({ cookie = null } = { cookie: null }) => {
     const { rockCookie, currentPerson } = this.context;
     const userCookie = cookie || rockCookie;


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

This PR attempts to prefetch the current user in the initialize step of the Auth Data Source. It doesn't always succeed as apollo server seems to prevent us from awaiting this. That means that occasionally the initialization will complete before other calls to getCurrentPerson, and in that one case, it will save calls to ROCK.

### What design trade-offs/decisions were made?

### How do I test this PR?

On a fresh build, try logging in or calling the auth mutation; you should see only one call to getCurrentPerson logged in your server

### What automated tests did you write?

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [x] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
