### PR TITLE
Add Configurability for ROCK Analytics

### DIFF
--- a/packages/apollos-church-api/config.yml
+++ b/packages/apollos-church-api/config.yml
@@ -50,6 +50,7 @@ ANALYTICS:
   # on the accompanying service
   SEGMENT_KEY:
   GA_ID:
+  USE_ROCK: true
 BIBLE_API:
   KEY: ${BIBLE_API_KEY}
   BIBLE_ID:

--- a/packages/apollos-data-connector-analytics/src/data-source.js
+++ b/packages/apollos-data-connector-analytics/src/data-source.js
@@ -16,7 +16,7 @@ const mapArrayToObject = (array = []) =>
 
 // Add interfaces to this function to get picked up automatically.
 export const getInterfaces = () => {
-  const interfaces = [new RockInteractions()];
+  const interfaces = ANALYTICS.USE_ROCK ? [new RockInteractions()] : [];
   if (ANALYTICS.SEGMENT_KEY) {
     interfaces.push(new SegmentInterface(ANALYTICS.SEGMENT_KEY));
   }


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Adds a config.yml variable that, when disabled, allows ROCK analytics to be disabled. This should reduce the load on ROCK should a partner church choose not to implement ROCK analytics.

### What design trade-offs/decisions were made?

### How do I test this PR?

I did this in a very rudimentary way. There is likely a better way to do this.

1. On ln 60 of `/apollos-church-api/src/server.js` add the following code `console.log(dataSources().Analytics.interfaces);`
2. Restart your server; you should see an array with the RockInteractionAnalytics interface
3. In config.yml, change ANALYTICS.USE_ROCK to false
4. Restart your server; you should see an empty interfaces array

### What automated tests did you write?

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [x] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
