### PR TITLE
Actually logs users with bad cookies out of the app

### DIFF
--- a/packages/apollos-data-connector-rock/src/auth/data-source.js
+++ b/packages/apollos-data-connector-rock/src/auth/data-source.js
@@ -31,13 +31,17 @@ export default class AuthDataSource extends RockApolloDataSource {
     }
 
     if (userCookie) {
-      const request = await this.request('People/GetCurrentPerson').get({
-        options: {
-          headers: { cookie: userCookie, 'Authorization-Token': null },
-        },
-      });
-      this.context.currentPerson = request;
-      return request;
+      try {
+        const request = await this.request('People/GetCurrentPerson').get({
+          options: {
+            headers: { cookie: userCookie, 'Authorization-Token': null },
+          },
+        });
+        this.context.currentPerson = request;
+        return request;
+      } catch (e) {
+        throw new AuthenticationError('Invalid user cookie');
+      }
     }
     throw new AuthenticationError('Must be logged in');
   };
@@ -107,6 +111,7 @@ export default class AuthDataSource extends RockApolloDataSource {
         Email: email,
         IsSystem: false, // Required by Rock
         Gender: 0, // Required by Rock
+        ConnectionStatusValueId: 5679, // "App User" - created by Willow
       });
     } catch (err) {
       throw new Error('Unable to create profile!');

--- a/packages/apollos-ui-auth/src/buildErrorLink.js
+++ b/packages/apollos-ui-auth/src/buildErrorLink.js
@@ -1,4 +1,5 @@
 import { onError } from 'apollo-link-error';
+import AsyncStorage from '@react-native-community/async-storage';
 
 export default (onAuthError) =>
   onError(({ graphQLErrors, networkError }) => {
@@ -6,6 +7,7 @@ export default (onAuthError) =>
       graphQLErrors.map(({ extensions: { code } }) => {
         // wipe out all data and go somewhere
         if (code === 'UNAUTHENTICATED') {
+          AsyncStorage.removeItem('authToken');
           onAuthError();
         }
         return null;


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Previously, if a user had an invalid cookie, they wouldn't get logged out of the app properly for two reasons: 

1. Invalid cookies don't throw a Authentication error, they throw a 500 error. 
2. Even when an authentication error was thrown, the `authToken` local storage state wasn't being cleared. 

Both of those issues are fixed in this PR. 

### What design trade-offs/decisions were made?

n/a

### How do I test this PR?

🤔
1. Change Auth Datasource to throw an Authentication error, and browse the app and make sure you get logged out? 
2. Hardcode a bad cookie in the client, make sure an Authentication error is thrown in Rock (rather than a 500 error) 

### What automated tests did you write?

n/a

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
