### PR TITLE
Adds additional server analytics

### DIFF
--- a/packages/apollos-ui-analytics/src/Provider.js
+++ b/packages/apollos-ui-analytics/src/Provider.js
@@ -47,11 +47,12 @@ export const track = ({ client, eventName, properties }) =>
     },
   });
 
+const identify = ({ client }) => client.mutate({ mutation: IDENTIFY_CLIENT });
+
 const createTrack = ({ client }) => ({ eventName, properties }) =>
   track({ eventName, properties, client });
 
-const createIdentify = ({ client }) => () =>
-  client.mutate({ mutation: IDENTIFY_CLIENT });
+const createIdentify = ({ client }) => () => identify({ client });
 
 export const createResolvers = ({ trackFunctions, identifyFunctions }) => ({
   Mutation: {

--- a/packages/apollos-ui-analytics/src/Provider.js
+++ b/packages/apollos-ui-analytics/src/Provider.js
@@ -47,7 +47,8 @@ export const track = ({ client, eventName, properties }) =>
     },
   });
 
-const identify = ({ client }) => client.mutate({ mutation: IDENTIFY_CLIENT });
+export const identify = ({ client }) =>
+  client.mutate({ mutation: IDENTIFY_CLIENT });
 
 const createTrack = ({ client }) => ({ eventName, properties }) =>
   track({ eventName, properties, client });

--- a/packages/apollos-ui-analytics/src/Provider.js
+++ b/packages/apollos-ui-analytics/src/Provider.js
@@ -54,7 +54,11 @@ const createTrack = ({ client }) => ({ eventName, properties }) =>
 
 const createIdentify = ({ client }) => () => identify({ client });
 
-export const createResolvers = ({ trackFunctions, identifyFunctions }) => ({
+export const createResolvers = ({
+  trackFunctions,
+  identifyFunctions,
+  useServerAnalytics = true,
+}) => ({
   Mutation: {
     track: async (root, { properties, eventName }, { client }) => {
       trackFunctions.forEach((func) => {
@@ -66,17 +70,19 @@ export const createResolvers = ({ trackFunctions, identifyFunctions }) => ({
           func({ eventName, properties: gqlInputToObject(properties) });
         }
       });
-      await client.mutate({
-        mutation: TRACK_SERVER,
-        variables: {
-          input: {
-            anonymousId,
-            deviceInfo,
-            eventName,
-            properties,
+      if (useServerAnalytics) {
+        await client.mutate({
+          mutation: TRACK_SERVER,
+          variables: {
+            input: {
+              anonymousId,
+              deviceInfo,
+              eventName,
+              properties,
+            },
           },
-        },
-      });
+        });
+      }
       return null;
     },
 
@@ -90,15 +96,17 @@ export const createResolvers = ({ trackFunctions, identifyFunctions }) => ({
           func();
         }
       });
-      await client.mutate({
-        mutation: IDENTIFY_SERVER,
-        variables: {
-          input: {
-            anonymousId,
-            deviceInfo,
+      if (useServerAnalytics) {
+        await client.mutate({
+          mutation: IDENTIFY_SERVER,
+          variables: {
+            input: {
+              anonymousId,
+              deviceInfo,
+            },
           },
-        },
-      });
+        });
+      }
       return null;
     },
   },

--- a/packages/apollos-ui-analytics/src/Provider.js
+++ b/packages/apollos-ui-analytics/src/Provider.js
@@ -146,11 +146,13 @@ Provider.propTypes = {
   children: PropTypes.node,
   trackFunctions: PropTypes.arrayOf(PropTypes.func),
   identifyFunctions: PropTypes.arrayOf(PropTypes.func),
+  useServerAnalytics: PropTypes.bool,
 };
 
 Provider.defaultProps = {
   trackFunctions: [],
   identifyFunctions: [],
+  useServerAnalytics: true,
 };
 
 export const AnalyticsConsumer = AnalyticsContext.Consumer;

--- a/packages/apollos-ui-analytics/src/Provider.js
+++ b/packages/apollos-ui-analytics/src/Provider.js
@@ -113,11 +113,20 @@ export const createResolvers = ({
   },
 });
 
-const Provider = ({ children, trackFunctions, identifyFunctions }) => (
+const Provider = ({
+  children,
+  trackFunctions,
+  identifyFunctions,
+  useServerAnalytics,
+}) => (
   <ApolloConsumer>
     {(client) => {
       client.addResolvers(
-        createResolvers({ trackFunctions, identifyFunctions })
+        createResolvers({
+          trackFunctions,
+          identifyFunctions,
+          useServerAnalytics,
+        })
       );
       return (
         <AnalyticsContext.Provider

--- a/packages/apollos-ui-analytics/src/index.js
+++ b/packages/apollos-ui-analytics/src/index.js
@@ -1,11 +1,16 @@
-import AnalyticsProvider, { AnalyticsConsumer, track } from './Provider';
+import AnalyticsProvider, {
+  AnalyticsConsumer,
+  identify,
+  track,
+} from './Provider';
 import TrackEventWhenLoaded from './TrackEventWhenLoaded';
 import withTrackOnPress from './withTrackOnPress';
 
 export {
   AnalyticsConsumer,
   AnalyticsProvider,
-  TrackEventWhenLoaded,
+  identify,
   track,
+  TrackEventWhenLoaded,
   withTrackOnPress,
 };


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Makes the server-side analytics optional. The variable should be passed as a prop to the analytics provider. If not passed, it defaults to `true`, which enables server-side analytics.

### What design trade-offs/decisions were made?

### How do I test this PR?

1. Pass false into the analytics provider and ensure that server-side analytics do not run. (I just put a log inside server analytics package)

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
