### PR TITLE
Ensures that n+3 redis connections aren't created

### DIFF
--- a/packages/apollos-data-connector-algolia-search/src/__tests__/__snapshots__/jobs.tests.js.snap
+++ b/packages/apollos-data-connector-algolia-search/src/__tests__/__snapshots__/jobs.tests.js.snap
@@ -36,9 +36,15 @@ exports[`Alolia search jobs must create a job and add it to the queue 3`] = `
 Array [
   Array [
     "algolia-full-index-queue",
+    Object {
+      "createClient": [Function],
+    },
   ],
   Array [
     "algolia-delta-index-queue",
+    Object {
+      "createClient": [Function],
+    },
   ],
 ]
 `;


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

`Bull` has some best practices for reducing the number of connections being created. Now, a maximum of 4 connections per server will be made to Redis. 

### What design trade-offs/decisions were made?

n/a

### How do I test this PR?

1. Run the api locally.
2. have redis setup locally. 
3. run `redis-cli client list` 
4. You should see 5 clients connected (4 for the server + 1 for the `client-list` command)
<img width="1573" alt="Screen Shot 2019-11-22 at 8 49 44 AM" src="https://user-images.githubusercontent.com/1637694/69432247-54fcb080-0d07-11ea-91b1-dfd745e841de.png">


### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
