### PR TITLE
Suppress Back Button Width

### DIFF
--- a/packages/apollos-ui-auth/src/BackButton.js
+++ b/packages/apollos-ui-auth/src/BackButton.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { View } from 'react-native';
+
+import {
+  UIText,
+  ButtonLink,
+  styled,
+  withTheme,
+  Touchable,
+  PaddedView,
+  Icon,
+} from '@apollosproject/ui-kit';
+
+const SuppressingView = styled(
+  {
+    flexDirection: 'row',
+  },
+  'ui-auth.BackButton.SuppressingView'
+)(View);
+
+const Button = withTheme(({ theme }) => ({
+  borderRadius: theme.sizing.baseUnit,
+}))(Touchable);
+
+const ButtonWrapper = styled(
+  {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  'ui-auth.BackButton.ButtonWrapper'
+)(PaddedView);
+
+const BackButtonIcon = withTheme(({ theme }) => ({
+  fill: theme.colors.action.secondary,
+  size: theme.sizing.baseUnit * 1.5,
+  style: {
+    paddingRight: 0,
+  },
+}))(Icon);
+
+const BackButton = ({ onPress }) => (
+  <SuppressingView>
+    <Button onPress={() => onPress()}>
+      <ButtonWrapper>
+        <BackButtonIcon name="arrow-back" />
+        <UIText>
+          <ButtonLink>Back</ButtonLink>
+        </UIText>
+      </ButtonWrapper>
+    </Button>
+  </SuppressingView>
+);
+
+BackButton.propTypes = {
+  onPress: PropTypes.func,
+};
+
+export default BackButton;

--- a/packages/apollos-ui-auth/src/Password/index.js
+++ b/packages/apollos-ui-auth/src/Password/index.js
@@ -7,33 +7,22 @@ import {
   TabView,
   PaddedView,
   TabSceneMap as SceneMap,
-  ButtonIcon,
-  styled,
-  withTheme,
+  ButtonLink,
+  UIText,
 } from '@apollosproject/ui-kit';
 import { SafeAreaView } from 'react-navigation';
 
-import { PromptText } from '../styles';
+import {
+  PromptText,
+  SuppressingView,
+  BackButtonTouchable,
+  BackButtonWrapper,
+  BackButton,
+} from '../styles';
 import { AuthConsumer } from '../Provider';
 import LoginForm from './Login';
 
 import SignUpForm from './Signup';
-
-const StyledPaddedView = styled(
-  {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  'ui-auth.Password.PaddedView'
-)(PaddedView);
-
-const BackButton = withTheme(({ theme }) => ({
-  fill: theme.colors.action.secondary,
-  size: theme.sizing.baseUnit * 1.5,
-  style: {
-    paddingLeft: 0,
-  },
-}))(ButtonIcon);
 
 class AuthPassword extends PureComponent {
   static navigationOptions = {
@@ -78,13 +67,21 @@ class AuthPassword extends PureComponent {
           >
             <BackgroundComponent>
               <SafeAreaView style={StyleSheet.absoluteFill}>
-                <StyledPaddedView>
-                  <BackButton
-                    name="arrow-back"
-                    onPress={() => this.props.navigation.goBack()}
-                  />
+                <PaddedView>
+                  <SuppressingView>
+                    <BackButtonTouchable
+                      onPress={() => this.props.navigation.goBack()}
+                    >
+                      <BackButtonWrapper horizontal={false}>
+                        <BackButton name="arrow-back" />
+                        <UIText>
+                          <ButtonLink>Back</ButtonLink>
+                        </UIText>
+                      </BackButtonWrapper>
+                    </BackButtonTouchable>
+                  </SuppressingView>
                   <PromptText>{this.flatProps.passwordPromptText}</PromptText>
-                </StyledPaddedView>
+                </PaddedView>
 
                 <TabView
                   routes={this.tabRoutes}

--- a/packages/apollos-ui-auth/src/Password/index.js
+++ b/packages/apollos-ui-auth/src/Password/index.js
@@ -7,18 +7,11 @@ import {
   TabView,
   PaddedView,
   TabSceneMap as SceneMap,
-  ButtonLink,
-  UIText,
 } from '@apollosproject/ui-kit';
 import { SafeAreaView } from 'react-navigation';
 
-import {
-  PromptText,
-  SuppressingView,
-  BackButtonTouchable,
-  BackButtonWrapper,
-  BackButton,
-} from '../styles';
+import { PromptText } from '../styles';
+import BackButton from '../BackButton';
 import { AuthConsumer } from '../Provider';
 import LoginForm from './Login';
 
@@ -67,19 +60,8 @@ class AuthPassword extends PureComponent {
           >
             <BackgroundComponent>
               <SafeAreaView style={StyleSheet.absoluteFill}>
-                <PaddedView>
-                  <SuppressingView>
-                    <BackButtonTouchable
-                      onPress={() => this.props.navigation.goBack()}
-                    >
-                      <BackButtonWrapper horizontal={false}>
-                        <BackButton name="arrow-back" />
-                        <UIText>
-                          <ButtonLink>Back</ButtonLink>
-                        </UIText>
-                      </BackButtonWrapper>
-                    </BackButtonTouchable>
-                  </SuppressingView>
+                <BackButton onPress={() => this.props.navigation.goBack()} />
+                <PaddedView vertical={false}>
                   <PromptText>{this.flatProps.passwordPromptText}</PromptText>
                 </PaddedView>
 

--- a/packages/apollos-ui-auth/src/SMS/Verification.js
+++ b/packages/apollos-ui-auth/src/SMS/Verification.js
@@ -6,16 +6,15 @@ import {
   ScrollView,
   Platform,
   StatusBar,
-  View,
 } from 'react-native';
 import { get } from 'lodash';
+
 import {
   PaddedView,
   TextInput,
   BackgroundView,
-  ButtonIcon,
-  withTheme,
-  styled,
+  UIText,
+  ButtonLink,
 } from '@apollosproject/ui-kit';
 
 import {
@@ -24,19 +23,11 @@ import {
   TitleText,
   PromptText,
   BrandIcon,
+  SuppressingView,
+  BackButtonTouchable,
+  BackButtonWrapper,
+  BackButton,
 } from '../styles';
-
-const BackButton = withTheme(({ theme }) => ({
-  fill: theme.colors.action.secondary,
-  size: theme.sizing.baseUnit * 1.5,
-  style: {
-    paddingLeft: 0,
-  },
-}))(ButtonIcon);
-
-const SuppressingView = styled(() => ({
-  flexDirection: 'row',
-}))(View);
 
 const Verification = ({
   confirmationTitleText,
@@ -60,10 +51,17 @@ const Verification = ({
     <BackgroundComponent>
       <FlexedSafeAreaView>
         <ScrollView>
-          <PaddedView>
-            <SuppressingView>
-              <BackButton name="arrow-back" onPress={() => onPressBack()} />
-            </SuppressingView>
+          <SuppressingView>
+            <BackButtonTouchable onPress={() => onPressBack()}>
+              <BackButtonWrapper>
+                <BackButton name="arrow-back" />
+                <UIText>
+                  <ButtonLink>Back</ButtonLink>
+                </UIText>
+              </BackButtonWrapper>
+            </BackButtonTouchable>
+          </SuppressingView>
+          <PaddedView vertical={false}>
             <BrandIcon />
             <TitleText>{confirmationTitleText}</TitleText>
             <PromptText padded>{confirmationPromptText}</PromptText>

--- a/packages/apollos-ui-auth/src/SMS/Verification.js
+++ b/packages/apollos-ui-auth/src/SMS/Verification.js
@@ -9,13 +9,7 @@ import {
 } from 'react-native';
 import { get } from 'lodash';
 
-import {
-  PaddedView,
-  TextInput,
-  BackgroundView,
-  UIText,
-  ButtonLink,
-} from '@apollosproject/ui-kit';
+import { PaddedView, TextInput, BackgroundView } from '@apollosproject/ui-kit';
 
 import {
   FlexedSafeAreaView,
@@ -23,11 +17,8 @@ import {
   TitleText,
   PromptText,
   BrandIcon,
-  SuppressingView,
-  BackButtonTouchable,
-  BackButtonWrapper,
-  BackButton,
 } from '../styles';
+import BackButton from '../BackButton';
 
 const Verification = ({
   confirmationTitleText,
@@ -51,16 +42,7 @@ const Verification = ({
     <BackgroundComponent>
       <FlexedSafeAreaView>
         <ScrollView>
-          <SuppressingView>
-            <BackButtonTouchable onPress={() => onPressBack()}>
-              <BackButtonWrapper>
-                <BackButton name="arrow-back" />
-                <UIText>
-                  <ButtonLink>Back</ButtonLink>
-                </UIText>
-              </BackButtonWrapper>
-            </BackButtonTouchable>
-          </SuppressingView>
+          <BackButton onPress={() => onPressBack()} />
           <PaddedView vertical={false}>
             <BrandIcon />
             <TitleText>{confirmationTitleText}</TitleText>

--- a/packages/apollos-ui-auth/src/SMS/Verification.js
+++ b/packages/apollos-ui-auth/src/SMS/Verification.js
@@ -6,6 +6,7 @@ import {
   ScrollView,
   Platform,
   StatusBar,
+  View,
 } from 'react-native';
 import { get } from 'lodash';
 import {
@@ -14,6 +15,7 @@ import {
   BackgroundView,
   ButtonIcon,
   withTheme,
+  styled,
 } from '@apollosproject/ui-kit';
 
 import {
@@ -31,6 +33,10 @@ const BackButton = withTheme(({ theme }) => ({
     paddingLeft: 0,
   },
 }))(ButtonIcon);
+
+const SuppressingView = styled(() => ({
+  flexDirection: 'row',
+}))(View);
 
 const Verification = ({
   confirmationTitleText,
@@ -55,7 +61,9 @@ const Verification = ({
       <FlexedSafeAreaView>
         <ScrollView>
           <PaddedView>
-            <BackButton name="arrow-back" onPress={() => onPressBack()} />
+            <SuppressingView>
+              <BackButton name="arrow-back" onPress={() => onPressBack()} />
+            </SuppressingView>
             <BrandIcon />
             <TitleText>{confirmationTitleText}</TitleText>
             <PromptText padded>{confirmationPromptText}</PromptText>

--- a/packages/apollos-ui-auth/src/SMS/__snapshots__/Verification.tests.js.snap
+++ b/packages/apollos-ui-auth/src/SMS/__snapshots__/Verification.tests.js.snap
@@ -69,112 +69,78 @@ exports[`The Auth Verification component should render 1`] = `
             }
           >
             <View
-              accessible={true}
-              clickable={true}
-              isTVSelectable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "opacity": 1,
+                  "flexDirection": "row",
                 }
               }
             >
               <View
-                borderRadius={48}
-                iconPadding={9.6}
+                accessible={true}
+                clickable={true}
+                isTVSelectable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
-                    "padding": 9.6,
-                    "paddingLeft": 0,
+                    "opacity": 1,
                   }
                 }
               >
-                <RNSVGSvgView
-                  align="xMidYMid"
-                  bbHeight={24}
-                  bbWidth={24}
-                  height={24}
-                  meetOrSlice={0}
-                  minX={0}
-                  minY={0}
+                <View
+                  borderRadius={48}
+                  iconPadding={9.6}
                   style={
-                    Array [
-                      Object {
-                        "backgroundColor": "transparent",
-                        "borderWidth": 0,
-                      },
-                      undefined,
-                      Object {
-                        "opacity": 1,
-                      },
-                      Object {
-                        "flex": 0,
-                        "height": 24,
-                        "width": 24,
-                      },
-                    ]
+                    Object {
+                      "padding": 9.6,
+                      "paddingLeft": 0,
+                    }
                   }
-                  vbHeight={24}
-                  vbWidth={24}
-                  width={24}
                 >
-                  <RNSVGGroup
-                    fill={
+                  <RNSVGSvgView
+                    align="xMidYMid"
+                    bbHeight={24}
+                    bbWidth={24}
+                    height={24}
+                    meetOrSlice={0}
+                    minX={0}
+                    minY={0}
+                    style={
                       Array [
-                        0,
-                        4278190080,
+                        Object {
+                          "backgroundColor": "transparent",
+                          "borderWidth": 0,
+                        },
+                        undefined,
+                        Object {
+                          "opacity": 1,
+                        },
+                        Object {
+                          "flex": 0,
+                          "height": 24,
+                          "width": 24,
+                        },
                       ]
                     }
-                    fillOpacity={1}
-                    fillRule={1}
-                    font={Object {}}
-                    matrix={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        1,
-                        0,
-                        0,
-                      ]
-                    }
-                    opacity={1}
-                    originX={0}
-                    originY={0}
-                    propList={Array []}
-                    rotation={0}
-                    scaleX={1}
-                    scaleY={1}
-                    skewX={0}
-                    skewY={0}
-                    stroke={null}
-                    strokeDasharray={null}
-                    strokeDashoffset={null}
-                    strokeLinecap={0}
-                    strokeLinejoin={0}
-                    strokeMiterlimit={4}
-                    strokeOpacity={1}
-                    strokeWidth={1}
-                    vectorEffect={0}
-                    x={0}
-                    y={0}
+                    vbHeight={24}
+                    vbWidth={24}
+                    width={24}
                   >
-                    <RNSVGPath
-                      d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
+                    <RNSVGGroup
                       fill={
                         Array [
                           0,
-                          4279743874,
+                          4278190080,
                         ]
                       }
                       fillOpacity={1}
                       fillRule={1}
+                      font={Object {}}
                       matrix={
                         Array [
                           1,
@@ -188,11 +154,7 @@ exports[`The Auth Verification component should render 1`] = `
                       opacity={1}
                       originX={0}
                       originY={0}
-                      propList={
-                        Array [
-                          "fill",
-                        ]
-                      }
+                      propList={Array []}
                       rotation={0}
                       scaleX={1}
                       scaleY={1}
@@ -209,9 +171,55 @@ exports[`The Auth Verification component should render 1`] = `
                       vectorEffect={0}
                       x={0}
                       y={0}
-                    />
-                  </RNSVGGroup>
-                </RNSVGSvgView>
+                    >
+                      <RNSVGPath
+                        d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
+                        fill={
+                          Array [
+                            0,
+                            4279743874,
+                          ]
+                        }
+                        fillOpacity={1}
+                        fillRule={1}
+                        matrix={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                        opacity={1}
+                        originX={0}
+                        originY={0}
+                        propList={
+                          Array [
+                            "fill",
+                          ]
+                        }
+                        rotation={0}
+                        scaleX={1}
+                        scaleY={1}
+                        skewX={0}
+                        skewY={0}
+                        stroke={null}
+                        strokeDasharray={null}
+                        strokeDashoffset={null}
+                        strokeLinecap={0}
+                        strokeLinejoin={0}
+                        strokeMiterlimit={4}
+                        strokeOpacity={1}
+                        strokeWidth={1}
+                        vectorEffect={0}
+                        x={0}
+                        y={0}
+                      />
+                    </RNSVGGroup>
+                  </RNSVGSvgView>
+                </View>
               </View>
             </View>
             <RNSVGSvgView
@@ -596,112 +604,78 @@ exports[`The Auth Verification component should render as disabled 1`] = `
             }
           >
             <View
-              accessible={true}
-              clickable={true}
-              isTVSelectable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "opacity": 1,
+                  "flexDirection": "row",
                 }
               }
             >
               <View
-                borderRadius={48}
-                iconPadding={9.6}
+                accessible={true}
+                clickable={true}
+                isTVSelectable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
-                    "padding": 9.6,
-                    "paddingLeft": 0,
+                    "opacity": 1,
                   }
                 }
               >
-                <RNSVGSvgView
-                  align="xMidYMid"
-                  bbHeight={24}
-                  bbWidth={24}
-                  height={24}
-                  meetOrSlice={0}
-                  minX={0}
-                  minY={0}
+                <View
+                  borderRadius={48}
+                  iconPadding={9.6}
                   style={
-                    Array [
-                      Object {
-                        "backgroundColor": "transparent",
-                        "borderWidth": 0,
-                      },
-                      undefined,
-                      Object {
-                        "opacity": 1,
-                      },
-                      Object {
-                        "flex": 0,
-                        "height": 24,
-                        "width": 24,
-                      },
-                    ]
+                    Object {
+                      "padding": 9.6,
+                      "paddingLeft": 0,
+                    }
                   }
-                  vbHeight={24}
-                  vbWidth={24}
-                  width={24}
                 >
-                  <RNSVGGroup
-                    fill={
+                  <RNSVGSvgView
+                    align="xMidYMid"
+                    bbHeight={24}
+                    bbWidth={24}
+                    height={24}
+                    meetOrSlice={0}
+                    minX={0}
+                    minY={0}
+                    style={
                       Array [
-                        0,
-                        4278190080,
+                        Object {
+                          "backgroundColor": "transparent",
+                          "borderWidth": 0,
+                        },
+                        undefined,
+                        Object {
+                          "opacity": 1,
+                        },
+                        Object {
+                          "flex": 0,
+                          "height": 24,
+                          "width": 24,
+                        },
                       ]
                     }
-                    fillOpacity={1}
-                    fillRule={1}
-                    font={Object {}}
-                    matrix={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        1,
-                        0,
-                        0,
-                      ]
-                    }
-                    opacity={1}
-                    originX={0}
-                    originY={0}
-                    propList={Array []}
-                    rotation={0}
-                    scaleX={1}
-                    scaleY={1}
-                    skewX={0}
-                    skewY={0}
-                    stroke={null}
-                    strokeDasharray={null}
-                    strokeDashoffset={null}
-                    strokeLinecap={0}
-                    strokeLinejoin={0}
-                    strokeMiterlimit={4}
-                    strokeOpacity={1}
-                    strokeWidth={1}
-                    vectorEffect={0}
-                    x={0}
-                    y={0}
+                    vbHeight={24}
+                    vbWidth={24}
+                    width={24}
                   >
-                    <RNSVGPath
-                      d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
+                    <RNSVGGroup
                       fill={
                         Array [
                           0,
-                          4279743874,
+                          4278190080,
                         ]
                       }
                       fillOpacity={1}
                       fillRule={1}
+                      font={Object {}}
                       matrix={
                         Array [
                           1,
@@ -715,11 +689,7 @@ exports[`The Auth Verification component should render as disabled 1`] = `
                       opacity={1}
                       originX={0}
                       originY={0}
-                      propList={
-                        Array [
-                          "fill",
-                        ]
-                      }
+                      propList={Array []}
                       rotation={0}
                       scaleX={1}
                       scaleY={1}
@@ -736,9 +706,55 @@ exports[`The Auth Verification component should render as disabled 1`] = `
                       vectorEffect={0}
                       x={0}
                       y={0}
-                    />
-                  </RNSVGGroup>
-                </RNSVGSvgView>
+                    >
+                      <RNSVGPath
+                        d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
+                        fill={
+                          Array [
+                            0,
+                            4279743874,
+                          ]
+                        }
+                        fillOpacity={1}
+                        fillRule={1}
+                        matrix={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                        opacity={1}
+                        originX={0}
+                        originY={0}
+                        propList={
+                          Array [
+                            "fill",
+                          ]
+                        }
+                        rotation={0}
+                        scaleX={1}
+                        scaleY={1}
+                        skewX={0}
+                        skewY={0}
+                        stroke={null}
+                        strokeDasharray={null}
+                        strokeDashoffset={null}
+                        strokeLinecap={0}
+                        strokeLinejoin={0}
+                        strokeMiterlimit={4}
+                        strokeOpacity={1}
+                        strokeWidth={1}
+                        vectorEffect={0}
+                        x={0}
+                        y={0}
+                      />
+                    </RNSVGGroup>
+                  </RNSVGSvgView>
+                </View>
               </View>
             </View>
             <RNSVGSvgView
@@ -1185,112 +1201,78 @@ exports[`The Auth Verification component should render in a loading state 1`] = 
             }
           >
             <View
-              accessible={true}
-              clickable={true}
-              isTVSelectable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "opacity": 1,
+                  "flexDirection": "row",
                 }
               }
             >
               <View
-                borderRadius={48}
-                iconPadding={9.6}
+                accessible={true}
+                clickable={true}
+                isTVSelectable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
-                    "padding": 9.6,
-                    "paddingLeft": 0,
+                    "opacity": 1,
                   }
                 }
               >
-                <RNSVGSvgView
-                  align="xMidYMid"
-                  bbHeight={24}
-                  bbWidth={24}
-                  height={24}
-                  meetOrSlice={0}
-                  minX={0}
-                  minY={0}
+                <View
+                  borderRadius={48}
+                  iconPadding={9.6}
                   style={
-                    Array [
-                      Object {
-                        "backgroundColor": "transparent",
-                        "borderWidth": 0,
-                      },
-                      undefined,
-                      Object {
-                        "opacity": 1,
-                      },
-                      Object {
-                        "flex": 0,
-                        "height": 24,
-                        "width": 24,
-                      },
-                    ]
+                    Object {
+                      "padding": 9.6,
+                      "paddingLeft": 0,
+                    }
                   }
-                  vbHeight={24}
-                  vbWidth={24}
-                  width={24}
                 >
-                  <RNSVGGroup
-                    fill={
+                  <RNSVGSvgView
+                    align="xMidYMid"
+                    bbHeight={24}
+                    bbWidth={24}
+                    height={24}
+                    meetOrSlice={0}
+                    minX={0}
+                    minY={0}
+                    style={
                       Array [
-                        0,
-                        4278190080,
+                        Object {
+                          "backgroundColor": "transparent",
+                          "borderWidth": 0,
+                        },
+                        undefined,
+                        Object {
+                          "opacity": 1,
+                        },
+                        Object {
+                          "flex": 0,
+                          "height": 24,
+                          "width": 24,
+                        },
                       ]
                     }
-                    fillOpacity={1}
-                    fillRule={1}
-                    font={Object {}}
-                    matrix={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        1,
-                        0,
-                        0,
-                      ]
-                    }
-                    opacity={1}
-                    originX={0}
-                    originY={0}
-                    propList={Array []}
-                    rotation={0}
-                    scaleX={1}
-                    scaleY={1}
-                    skewX={0}
-                    skewY={0}
-                    stroke={null}
-                    strokeDasharray={null}
-                    strokeDashoffset={null}
-                    strokeLinecap={0}
-                    strokeLinejoin={0}
-                    strokeMiterlimit={4}
-                    strokeOpacity={1}
-                    strokeWidth={1}
-                    vectorEffect={0}
-                    x={0}
-                    y={0}
+                    vbHeight={24}
+                    vbWidth={24}
+                    width={24}
                   >
-                    <RNSVGPath
-                      d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
+                    <RNSVGGroup
                       fill={
                         Array [
                           0,
-                          4279743874,
+                          4278190080,
                         ]
                       }
                       fillOpacity={1}
                       fillRule={1}
+                      font={Object {}}
                       matrix={
                         Array [
                           1,
@@ -1304,11 +1286,7 @@ exports[`The Auth Verification component should render in a loading state 1`] = 
                       opacity={1}
                       originX={0}
                       originY={0}
-                      propList={
-                        Array [
-                          "fill",
-                        ]
-                      }
+                      propList={Array []}
                       rotation={0}
                       scaleX={1}
                       scaleY={1}
@@ -1325,9 +1303,55 @@ exports[`The Auth Verification component should render in a loading state 1`] = 
                       vectorEffect={0}
                       x={0}
                       y={0}
-                    />
-                  </RNSVGGroup>
-                </RNSVGSvgView>
+                    >
+                      <RNSVGPath
+                        d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
+                        fill={
+                          Array [
+                            0,
+                            4279743874,
+                          ]
+                        }
+                        fillOpacity={1}
+                        fillRule={1}
+                        matrix={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                        opacity={1}
+                        originX={0}
+                        originY={0}
+                        propList={
+                          Array [
+                            "fill",
+                          ]
+                        }
+                        rotation={0}
+                        scaleX={1}
+                        scaleY={1}
+                        skewX={0}
+                        skewY={0}
+                        stroke={null}
+                        strokeDasharray={null}
+                        strokeDashoffset={null}
+                        strokeLinecap={0}
+                        strokeLinejoin={0}
+                        strokeMiterlimit={4}
+                        strokeOpacity={1}
+                        strokeWidth={1}
+                        vectorEffect={0}
+                        x={0}
+                        y={0}
+                      />
+                    </RNSVGGroup>
+                  </RNSVGSvgView>
+                </View>
               </View>
             </View>
             <RNSVGSvgView
@@ -1768,112 +1792,78 @@ exports[`The Auth Verification component should render in a next button 1`] = `
             }
           >
             <View
-              accessible={true}
-              clickable={true}
-              isTVSelectable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "opacity": 1,
+                  "flexDirection": "row",
                 }
               }
             >
               <View
-                borderRadius={48}
-                iconPadding={9.6}
+                accessible={true}
+                clickable={true}
+                isTVSelectable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
-                    "padding": 9.6,
-                    "paddingLeft": 0,
+                    "opacity": 1,
                   }
                 }
               >
-                <RNSVGSvgView
-                  align="xMidYMid"
-                  bbHeight={24}
-                  bbWidth={24}
-                  height={24}
-                  meetOrSlice={0}
-                  minX={0}
-                  minY={0}
+                <View
+                  borderRadius={48}
+                  iconPadding={9.6}
                   style={
-                    Array [
-                      Object {
-                        "backgroundColor": "transparent",
-                        "borderWidth": 0,
-                      },
-                      undefined,
-                      Object {
-                        "opacity": 1,
-                      },
-                      Object {
-                        "flex": 0,
-                        "height": 24,
-                        "width": 24,
-                      },
-                    ]
+                    Object {
+                      "padding": 9.6,
+                      "paddingLeft": 0,
+                    }
                   }
-                  vbHeight={24}
-                  vbWidth={24}
-                  width={24}
                 >
-                  <RNSVGGroup
-                    fill={
+                  <RNSVGSvgView
+                    align="xMidYMid"
+                    bbHeight={24}
+                    bbWidth={24}
+                    height={24}
+                    meetOrSlice={0}
+                    minX={0}
+                    minY={0}
+                    style={
                       Array [
-                        0,
-                        4278190080,
+                        Object {
+                          "backgroundColor": "transparent",
+                          "borderWidth": 0,
+                        },
+                        undefined,
+                        Object {
+                          "opacity": 1,
+                        },
+                        Object {
+                          "flex": 0,
+                          "height": 24,
+                          "width": 24,
+                        },
                       ]
                     }
-                    fillOpacity={1}
-                    fillRule={1}
-                    font={Object {}}
-                    matrix={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        1,
-                        0,
-                        0,
-                      ]
-                    }
-                    opacity={1}
-                    originX={0}
-                    originY={0}
-                    propList={Array []}
-                    rotation={0}
-                    scaleX={1}
-                    scaleY={1}
-                    skewX={0}
-                    skewY={0}
-                    stroke={null}
-                    strokeDasharray={null}
-                    strokeDashoffset={null}
-                    strokeLinecap={0}
-                    strokeLinejoin={0}
-                    strokeMiterlimit={4}
-                    strokeOpacity={1}
-                    strokeWidth={1}
-                    vectorEffect={0}
-                    x={0}
-                    y={0}
+                    vbHeight={24}
+                    vbWidth={24}
+                    width={24}
                   >
-                    <RNSVGPath
-                      d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
+                    <RNSVGGroup
                       fill={
                         Array [
                           0,
-                          4279743874,
+                          4278190080,
                         ]
                       }
                       fillOpacity={1}
                       fillRule={1}
+                      font={Object {}}
                       matrix={
                         Array [
                           1,
@@ -1887,11 +1877,7 @@ exports[`The Auth Verification component should render in a next button 1`] = `
                       opacity={1}
                       originX={0}
                       originY={0}
-                      propList={
-                        Array [
-                          "fill",
-                        ]
-                      }
+                      propList={Array []}
                       rotation={0}
                       scaleX={1}
                       scaleY={1}
@@ -1908,9 +1894,55 @@ exports[`The Auth Verification component should render in a next button 1`] = `
                       vectorEffect={0}
                       x={0}
                       y={0}
-                    />
-                  </RNSVGGroup>
-                </RNSVGSvgView>
+                    >
+                      <RNSVGPath
+                        d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
+                        fill={
+                          Array [
+                            0,
+                            4279743874,
+                          ]
+                        }
+                        fillOpacity={1}
+                        fillRule={1}
+                        matrix={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                        opacity={1}
+                        originX={0}
+                        originY={0}
+                        propList={
+                          Array [
+                            "fill",
+                          ]
+                        }
+                        rotation={0}
+                        scaleX={1}
+                        scaleY={1}
+                        skewX={0}
+                        skewY={0}
+                        stroke={null}
+                        strokeDasharray={null}
+                        strokeDashoffset={null}
+                        strokeLinecap={0}
+                        strokeLinejoin={0}
+                        strokeMiterlimit={4}
+                        strokeOpacity={1}
+                        strokeWidth={1}
+                        vectorEffect={0}
+                        x={0}
+                        y={0}
+                      />
+                    </RNSVGGroup>
+                  </RNSVGSvgView>
+                </View>
               </View>
             </View>
             <RNSVGSvgView
@@ -2357,112 +2389,78 @@ exports[`The Auth Verification component should render in an error state 1`] = `
             }
           >
             <View
-              accessible={true}
-              clickable={true}
-              isTVSelectable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "opacity": 1,
+                  "flexDirection": "row",
                 }
               }
             >
               <View
-                borderRadius={48}
-                iconPadding={9.6}
+                accessible={true}
+                clickable={true}
+                isTVSelectable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
-                    "padding": 9.6,
-                    "paddingLeft": 0,
+                    "opacity": 1,
                   }
                 }
               >
-                <RNSVGSvgView
-                  align="xMidYMid"
-                  bbHeight={24}
-                  bbWidth={24}
-                  height={24}
-                  meetOrSlice={0}
-                  minX={0}
-                  minY={0}
+                <View
+                  borderRadius={48}
+                  iconPadding={9.6}
                   style={
-                    Array [
-                      Object {
-                        "backgroundColor": "transparent",
-                        "borderWidth": 0,
-                      },
-                      undefined,
-                      Object {
-                        "opacity": 1,
-                      },
-                      Object {
-                        "flex": 0,
-                        "height": 24,
-                        "width": 24,
-                      },
-                    ]
+                    Object {
+                      "padding": 9.6,
+                      "paddingLeft": 0,
+                    }
                   }
-                  vbHeight={24}
-                  vbWidth={24}
-                  width={24}
                 >
-                  <RNSVGGroup
-                    fill={
+                  <RNSVGSvgView
+                    align="xMidYMid"
+                    bbHeight={24}
+                    bbWidth={24}
+                    height={24}
+                    meetOrSlice={0}
+                    minX={0}
+                    minY={0}
+                    style={
                       Array [
-                        0,
-                        4278190080,
+                        Object {
+                          "backgroundColor": "transparent",
+                          "borderWidth": 0,
+                        },
+                        undefined,
+                        Object {
+                          "opacity": 1,
+                        },
+                        Object {
+                          "flex": 0,
+                          "height": 24,
+                          "width": 24,
+                        },
                       ]
                     }
-                    fillOpacity={1}
-                    fillRule={1}
-                    font={Object {}}
-                    matrix={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        1,
-                        0,
-                        0,
-                      ]
-                    }
-                    opacity={1}
-                    originX={0}
-                    originY={0}
-                    propList={Array []}
-                    rotation={0}
-                    scaleX={1}
-                    scaleY={1}
-                    skewX={0}
-                    skewY={0}
-                    stroke={null}
-                    strokeDasharray={null}
-                    strokeDashoffset={null}
-                    strokeLinecap={0}
-                    strokeLinejoin={0}
-                    strokeMiterlimit={4}
-                    strokeOpacity={1}
-                    strokeWidth={1}
-                    vectorEffect={0}
-                    x={0}
-                    y={0}
+                    vbHeight={24}
+                    vbWidth={24}
+                    width={24}
                   >
-                    <RNSVGPath
-                      d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
+                    <RNSVGGroup
                       fill={
                         Array [
                           0,
-                          4279743874,
+                          4278190080,
                         ]
                       }
                       fillOpacity={1}
                       fillRule={1}
+                      font={Object {}}
                       matrix={
                         Array [
                           1,
@@ -2476,11 +2474,7 @@ exports[`The Auth Verification component should render in an error state 1`] = `
                       opacity={1}
                       originX={0}
                       originY={0}
-                      propList={
-                        Array [
-                          "fill",
-                        ]
-                      }
+                      propList={Array []}
                       rotation={0}
                       scaleX={1}
                       scaleY={1}
@@ -2497,9 +2491,55 @@ exports[`The Auth Verification component should render in an error state 1`] = `
                       vectorEffect={0}
                       x={0}
                       y={0}
-                    />
-                  </RNSVGGroup>
-                </RNSVGSvgView>
+                    >
+                      <RNSVGPath
+                        d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
+                        fill={
+                          Array [
+                            0,
+                            4279743874,
+                          ]
+                        }
+                        fillOpacity={1}
+                        fillRule={1}
+                        matrix={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                        opacity={1}
+                        originX={0}
+                        originY={0}
+                        propList={
+                          Array [
+                            "fill",
+                          ]
+                        }
+                        rotation={0}
+                        scaleX={1}
+                        scaleY={1}
+                        skewX={0}
+                        skewY={0}
+                        stroke={null}
+                        strokeDasharray={null}
+                        strokeDashoffset={null}
+                        strokeLinecap={0}
+                        strokeLinejoin={0}
+                        strokeMiterlimit={4}
+                        strokeOpacity={1}
+                        strokeWidth={1}
+                        vectorEffect={0}
+                        x={0}
+                        y={0}
+                      />
+                    </RNSVGGroup>
+                  </RNSVGSvgView>
+                </View>
               </View>
             </View>
             <RNSVGSvgView
@@ -2897,112 +2937,78 @@ exports[`The Auth Verification component should render with a custom confirmatio
             }
           >
             <View
-              accessible={true}
-              clickable={true}
-              isTVSelectable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "opacity": 1,
+                  "flexDirection": "row",
                 }
               }
             >
               <View
-                borderRadius={48}
-                iconPadding={9.6}
+                accessible={true}
+                clickable={true}
+                isTVSelectable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
-                    "padding": 9.6,
-                    "paddingLeft": 0,
+                    "opacity": 1,
                   }
                 }
               >
-                <RNSVGSvgView
-                  align="xMidYMid"
-                  bbHeight={24}
-                  bbWidth={24}
-                  height={24}
-                  meetOrSlice={0}
-                  minX={0}
-                  minY={0}
+                <View
+                  borderRadius={48}
+                  iconPadding={9.6}
                   style={
-                    Array [
-                      Object {
-                        "backgroundColor": "transparent",
-                        "borderWidth": 0,
-                      },
-                      undefined,
-                      Object {
-                        "opacity": 1,
-                      },
-                      Object {
-                        "flex": 0,
-                        "height": 24,
-                        "width": 24,
-                      },
-                    ]
+                    Object {
+                      "padding": 9.6,
+                      "paddingLeft": 0,
+                    }
                   }
-                  vbHeight={24}
-                  vbWidth={24}
-                  width={24}
                 >
-                  <RNSVGGroup
-                    fill={
+                  <RNSVGSvgView
+                    align="xMidYMid"
+                    bbHeight={24}
+                    bbWidth={24}
+                    height={24}
+                    meetOrSlice={0}
+                    minX={0}
+                    minY={0}
+                    style={
                       Array [
-                        0,
-                        4278190080,
+                        Object {
+                          "backgroundColor": "transparent",
+                          "borderWidth": 0,
+                        },
+                        undefined,
+                        Object {
+                          "opacity": 1,
+                        },
+                        Object {
+                          "flex": 0,
+                          "height": 24,
+                          "width": 24,
+                        },
                       ]
                     }
-                    fillOpacity={1}
-                    fillRule={1}
-                    font={Object {}}
-                    matrix={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        1,
-                        0,
-                        0,
-                      ]
-                    }
-                    opacity={1}
-                    originX={0}
-                    originY={0}
-                    propList={Array []}
-                    rotation={0}
-                    scaleX={1}
-                    scaleY={1}
-                    skewX={0}
-                    skewY={0}
-                    stroke={null}
-                    strokeDasharray={null}
-                    strokeDashoffset={null}
-                    strokeLinecap={0}
-                    strokeLinejoin={0}
-                    strokeMiterlimit={4}
-                    strokeOpacity={1}
-                    strokeWidth={1}
-                    vectorEffect={0}
-                    x={0}
-                    y={0}
+                    vbHeight={24}
+                    vbWidth={24}
+                    width={24}
                   >
-                    <RNSVGPath
-                      d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
+                    <RNSVGGroup
                       fill={
                         Array [
                           0,
-                          4279743874,
+                          4278190080,
                         ]
                       }
                       fillOpacity={1}
                       fillRule={1}
+                      font={Object {}}
                       matrix={
                         Array [
                           1,
@@ -3016,11 +3022,7 @@ exports[`The Auth Verification component should render with a custom confirmatio
                       opacity={1}
                       originX={0}
                       originY={0}
-                      propList={
-                        Array [
-                          "fill",
-                        ]
-                      }
+                      propList={Array []}
                       rotation={0}
                       scaleX={1}
                       scaleY={1}
@@ -3037,9 +3039,55 @@ exports[`The Auth Verification component should render with a custom confirmatio
                       vectorEffect={0}
                       x={0}
                       y={0}
-                    />
-                  </RNSVGGroup>
-                </RNSVGSvgView>
+                    >
+                      <RNSVGPath
+                        d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
+                        fill={
+                          Array [
+                            0,
+                            4279743874,
+                          ]
+                        }
+                        fillOpacity={1}
+                        fillRule={1}
+                        matrix={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                        opacity={1}
+                        originX={0}
+                        originY={0}
+                        propList={
+                          Array [
+                            "fill",
+                          ]
+                        }
+                        rotation={0}
+                        scaleX={1}
+                        scaleY={1}
+                        skewX={0}
+                        skewY={0}
+                        stroke={null}
+                        strokeDasharray={null}
+                        strokeDashoffset={null}
+                        strokeLinecap={0}
+                        strokeLinejoin={0}
+                        strokeMiterlimit={4}
+                        strokeOpacity={1}
+                        strokeWidth={1}
+                        vectorEffect={0}
+                        x={0}
+                        y={0}
+                      />
+                    </RNSVGGroup>
+                  </RNSVGSvgView>
+                </View>
               </View>
             </View>
             <RNSVGSvgView
@@ -3424,112 +3472,78 @@ exports[`The Auth Verification component should render with a value 1`] = `
             }
           >
             <View
-              accessible={true}
-              clickable={true}
-              isTVSelectable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "opacity": 1,
+                  "flexDirection": "row",
                 }
               }
             >
               <View
-                borderRadius={48}
-                iconPadding={9.6}
+                accessible={true}
+                clickable={true}
+                isTVSelectable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
-                    "padding": 9.6,
-                    "paddingLeft": 0,
+                    "opacity": 1,
                   }
                 }
               >
-                <RNSVGSvgView
-                  align="xMidYMid"
-                  bbHeight={24}
-                  bbWidth={24}
-                  height={24}
-                  meetOrSlice={0}
-                  minX={0}
-                  minY={0}
+                <View
+                  borderRadius={48}
+                  iconPadding={9.6}
                   style={
-                    Array [
-                      Object {
-                        "backgroundColor": "transparent",
-                        "borderWidth": 0,
-                      },
-                      undefined,
-                      Object {
-                        "opacity": 1,
-                      },
-                      Object {
-                        "flex": 0,
-                        "height": 24,
-                        "width": 24,
-                      },
-                    ]
+                    Object {
+                      "padding": 9.6,
+                      "paddingLeft": 0,
+                    }
                   }
-                  vbHeight={24}
-                  vbWidth={24}
-                  width={24}
                 >
-                  <RNSVGGroup
-                    fill={
+                  <RNSVGSvgView
+                    align="xMidYMid"
+                    bbHeight={24}
+                    bbWidth={24}
+                    height={24}
+                    meetOrSlice={0}
+                    minX={0}
+                    minY={0}
+                    style={
                       Array [
-                        0,
-                        4278190080,
+                        Object {
+                          "backgroundColor": "transparent",
+                          "borderWidth": 0,
+                        },
+                        undefined,
+                        Object {
+                          "opacity": 1,
+                        },
+                        Object {
+                          "flex": 0,
+                          "height": 24,
+                          "width": 24,
+                        },
                       ]
                     }
-                    fillOpacity={1}
-                    fillRule={1}
-                    font={Object {}}
-                    matrix={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        1,
-                        0,
-                        0,
-                      ]
-                    }
-                    opacity={1}
-                    originX={0}
-                    originY={0}
-                    propList={Array []}
-                    rotation={0}
-                    scaleX={1}
-                    scaleY={1}
-                    skewX={0}
-                    skewY={0}
-                    stroke={null}
-                    strokeDasharray={null}
-                    strokeDashoffset={null}
-                    strokeLinecap={0}
-                    strokeLinejoin={0}
-                    strokeMiterlimit={4}
-                    strokeOpacity={1}
-                    strokeWidth={1}
-                    vectorEffect={0}
-                    x={0}
-                    y={0}
+                    vbHeight={24}
+                    vbWidth={24}
+                    width={24}
                   >
-                    <RNSVGPath
-                      d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
+                    <RNSVGGroup
                       fill={
                         Array [
                           0,
-                          4279743874,
+                          4278190080,
                         ]
                       }
                       fillOpacity={1}
                       fillRule={1}
+                      font={Object {}}
                       matrix={
                         Array [
                           1,
@@ -3543,11 +3557,7 @@ exports[`The Auth Verification component should render with a value 1`] = `
                       opacity={1}
                       originX={0}
                       originY={0}
-                      propList={
-                        Array [
-                          "fill",
-                        ]
-                      }
+                      propList={Array []}
                       rotation={0}
                       scaleX={1}
                       scaleY={1}
@@ -3564,9 +3574,55 @@ exports[`The Auth Verification component should render with a value 1`] = `
                       vectorEffect={0}
                       x={0}
                       y={0}
-                    />
-                  </RNSVGGroup>
-                </RNSVGSvgView>
+                    >
+                      <RNSVGPath
+                        d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
+                        fill={
+                          Array [
+                            0,
+                            4279743874,
+                          ]
+                        }
+                        fillOpacity={1}
+                        fillRule={1}
+                        matrix={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                        opacity={1}
+                        originX={0}
+                        originY={0}
+                        propList={
+                          Array [
+                            "fill",
+                          ]
+                        }
+                        rotation={0}
+                        scaleX={1}
+                        scaleY={1}
+                        skewX={0}
+                        skewY={0}
+                        stroke={null}
+                        strokeDasharray={null}
+                        strokeDashoffset={null}
+                        strokeLinecap={0}
+                        strokeLinejoin={0}
+                        strokeMiterlimit={4}
+                        strokeOpacity={1}
+                        strokeWidth={1}
+                        vectorEffect={0}
+                        x={0}
+                        y={0}
+                      />
+                    </RNSVGGroup>
+                  </RNSVGSvgView>
+                </View>
               </View>
             </View>
             <RNSVGSvgView
@@ -3952,112 +4008,78 @@ exports[`The Auth Verification component should render with custom confirmationT
             }
           >
             <View
-              accessible={true}
-              clickable={true}
-              isTVSelectable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "opacity": 1,
+                  "flexDirection": "row",
                 }
               }
             >
               <View
-                borderRadius={48}
-                iconPadding={9.6}
+                accessible={true}
+                clickable={true}
+                isTVSelectable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
-                    "padding": 9.6,
-                    "paddingLeft": 0,
+                    "opacity": 1,
                   }
                 }
               >
-                <RNSVGSvgView
-                  align="xMidYMid"
-                  bbHeight={24}
-                  bbWidth={24}
-                  height={24}
-                  meetOrSlice={0}
-                  minX={0}
-                  minY={0}
+                <View
+                  borderRadius={48}
+                  iconPadding={9.6}
                   style={
-                    Array [
-                      Object {
-                        "backgroundColor": "transparent",
-                        "borderWidth": 0,
-                      },
-                      undefined,
-                      Object {
-                        "opacity": 1,
-                      },
-                      Object {
-                        "flex": 0,
-                        "height": 24,
-                        "width": 24,
-                      },
-                    ]
+                    Object {
+                      "padding": 9.6,
+                      "paddingLeft": 0,
+                    }
                   }
-                  vbHeight={24}
-                  vbWidth={24}
-                  width={24}
                 >
-                  <RNSVGGroup
-                    fill={
+                  <RNSVGSvgView
+                    align="xMidYMid"
+                    bbHeight={24}
+                    bbWidth={24}
+                    height={24}
+                    meetOrSlice={0}
+                    minX={0}
+                    minY={0}
+                    style={
                       Array [
-                        0,
-                        4278190080,
+                        Object {
+                          "backgroundColor": "transparent",
+                          "borderWidth": 0,
+                        },
+                        undefined,
+                        Object {
+                          "opacity": 1,
+                        },
+                        Object {
+                          "flex": 0,
+                          "height": 24,
+                          "width": 24,
+                        },
                       ]
                     }
-                    fillOpacity={1}
-                    fillRule={1}
-                    font={Object {}}
-                    matrix={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        1,
-                        0,
-                        0,
-                      ]
-                    }
-                    opacity={1}
-                    originX={0}
-                    originY={0}
-                    propList={Array []}
-                    rotation={0}
-                    scaleX={1}
-                    scaleY={1}
-                    skewX={0}
-                    skewY={0}
-                    stroke={null}
-                    strokeDasharray={null}
-                    strokeDashoffset={null}
-                    strokeLinecap={0}
-                    strokeLinejoin={0}
-                    strokeMiterlimit={4}
-                    strokeOpacity={1}
-                    strokeWidth={1}
-                    vectorEffect={0}
-                    x={0}
-                    y={0}
+                    vbHeight={24}
+                    vbWidth={24}
+                    width={24}
                   >
-                    <RNSVGPath
-                      d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
+                    <RNSVGGroup
                       fill={
                         Array [
                           0,
-                          4279743874,
+                          4278190080,
                         ]
                       }
                       fillOpacity={1}
                       fillRule={1}
+                      font={Object {}}
                       matrix={
                         Array [
                           1,
@@ -4071,11 +4093,7 @@ exports[`The Auth Verification component should render with custom confirmationT
                       opacity={1}
                       originX={0}
                       originY={0}
-                      propList={
-                        Array [
-                          "fill",
-                        ]
-                      }
+                      propList={Array []}
                       rotation={0}
                       scaleX={1}
                       scaleY={1}
@@ -4092,9 +4110,55 @@ exports[`The Auth Verification component should render with custom confirmationT
                       vectorEffect={0}
                       x={0}
                       y={0}
-                    />
-                  </RNSVGGroup>
-                </RNSVGSvgView>
+                    >
+                      <RNSVGPath
+                        d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
+                        fill={
+                          Array [
+                            0,
+                            4279743874,
+                          ]
+                        }
+                        fillOpacity={1}
+                        fillRule={1}
+                        matrix={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                        opacity={1}
+                        originX={0}
+                        originY={0}
+                        propList={
+                          Array [
+                            "fill",
+                          ]
+                        }
+                        rotation={0}
+                        scaleX={1}
+                        scaleY={1}
+                        skewX={0}
+                        skewY={0}
+                        stroke={null}
+                        strokeDasharray={null}
+                        strokeDashoffset={null}
+                        strokeLinecap={0}
+                        strokeLinejoin={0}
+                        strokeMiterlimit={4}
+                        strokeOpacity={1}
+                        strokeWidth={1}
+                        vectorEffect={0}
+                        x={0}
+                        y={0}
+                      />
+                    </RNSVGGroup>
+                  </RNSVGSvgView>
+                </View>
               </View>
             </View>
             <RNSVGSvgView

--- a/packages/apollos-ui-auth/src/SMS/__snapshots__/Verification.tests.js.snap
+++ b/packages/apollos-ui-auth/src/SMS/__snapshots__/Verification.tests.js.snap
@@ -63,84 +63,117 @@ exports[`The Auth Verification component should render 1`] = `
           <View
             style={
               Object {
-                "paddingHorizontal": 16,
-                "paddingVertical": 16,
+                "flexDirection": "row",
               }
             }
           >
             <View
+              accessible={true}
+              clickable={true}
+              isTVSelectable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "flexDirection": "row",
+                  "opacity": 1,
                 }
               }
             >
               <View
-                accessible={true}
-                clickable={true}
-                isTVSelectable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
-                    "opacity": 1,
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "paddingHorizontal": 16,
+                    "paddingVertical": 16,
                   }
                 }
               >
-                <View
-                  borderRadius={48}
-                  iconPadding={9.6}
+                <RNSVGSvgView
+                  align="xMidYMid"
+                  bbHeight={24}
+                  bbWidth={24}
+                  height={24}
+                  meetOrSlice={0}
+                  minX={0}
+                  minY={0}
                   style={
-                    Object {
-                      "padding": 9.6,
-                      "paddingLeft": 0,
-                    }
+                    Array [
+                      Object {
+                        "backgroundColor": "transparent",
+                        "borderWidth": 0,
+                      },
+                      Object {
+                        "paddingRight": 0,
+                      },
+                      null,
+                      Object {
+                        "flex": 0,
+                        "height": 24,
+                        "width": 24,
+                      },
+                    ]
                   }
+                  vbHeight={24}
+                  vbWidth={24}
+                  width={24}
                 >
-                  <RNSVGSvgView
-                    align="xMidYMid"
-                    bbHeight={24}
-                    bbWidth={24}
-                    height={24}
-                    meetOrSlice={0}
-                    minX={0}
-                    minY={0}
-                    style={
+                  <RNSVGGroup
+                    fill={
                       Array [
-                        Object {
-                          "backgroundColor": "transparent",
-                          "borderWidth": 0,
-                        },
-                        undefined,
-                        Object {
-                          "opacity": 1,
-                        },
-                        Object {
-                          "flex": 0,
-                          "height": 24,
-                          "width": 24,
-                        },
+                        0,
+                        4278190080,
                       ]
                     }
-                    vbHeight={24}
-                    vbWidth={24}
-                    width={24}
+                    fillOpacity={1}
+                    fillRule={1}
+                    font={Object {}}
+                    matrix={
+                      Array [
+                        1,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                      ]
+                    }
+                    opacity={1}
+                    originX={0}
+                    originY={0}
+                    propList={Array []}
+                    rotation={0}
+                    scaleX={1}
+                    scaleY={1}
+                    skewX={0}
+                    skewY={0}
+                    stroke={null}
+                    strokeDasharray={null}
+                    strokeDashoffset={null}
+                    strokeLinecap={0}
+                    strokeLinejoin={0}
+                    strokeMiterlimit={4}
+                    strokeOpacity={1}
+                    strokeWidth={1}
+                    vectorEffect={0}
+                    x={0}
+                    y={0}
                   >
-                    <RNSVGGroup
+                    <RNSVGPath
+                      d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
                       fill={
                         Array [
                           0,
-                          4278190080,
+                          4279743874,
                         ]
                       }
                       fillOpacity={1}
                       fillRule={1}
-                      font={Object {}}
                       matrix={
                         Array [
                           1,
@@ -154,7 +187,11 @@ exports[`The Auth Verification component should render 1`] = `
                       opacity={1}
                       originX={0}
                       originY={0}
-                      propList={Array []}
+                      propList={
+                        Array [
+                          "fill",
+                        ]
+                      }
                       rotation={0}
                       scaleX={1}
                       scaleY={1}
@@ -171,57 +208,43 @@ exports[`The Auth Verification component should render 1`] = `
                       vectorEffect={0}
                       x={0}
                       y={0}
-                    >
-                      <RNSVGPath
-                        d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
-                        fill={
-                          Array [
-                            0,
-                            4279743874,
-                          ]
-                        }
-                        fillOpacity={1}
-                        fillRule={1}
-                        matrix={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                        opacity={1}
-                        originX={0}
-                        originY={0}
-                        propList={
-                          Array [
-                            "fill",
-                          ]
-                        }
-                        rotation={0}
-                        scaleX={1}
-                        scaleY={1}
-                        skewX={0}
-                        skewY={0}
-                        stroke={null}
-                        strokeDasharray={null}
-                        strokeDashoffset={null}
-                        strokeLinecap={0}
-                        strokeLinejoin={0}
-                        strokeMiterlimit={4}
-                        strokeOpacity={1}
-                        strokeWidth={1}
-                        vectorEffect={0}
-                        x={0}
-                        y={0}
-                      />
-                    </RNSVGGroup>
-                  </RNSVGSvgView>
-                </View>
+                    />
+                  </RNSVGGroup>
+                </RNSVGSvgView>
+                <Text
+                  style={
+                    Object {
+                      "color": "#303030",
+                      "fontFamily": "System",
+                      "fontSize": 14,
+                      "fontStyle": null,
+                      "fontWeight": null,
+                      "lineHeight": 20.16,
+                    }
+                  }
+                >
+                  <Text
+                    style={
+                      Object {
+                        "color": "#17B582",
+                      }
+                    }
+                  >
+                    Back
+                  </Text>
+                </Text>
               </View>
             </View>
+          </View>
+          <View
+            style={
+              Object {
+                "paddingHorizontal": 16,
+                "paddingVertical": 0,
+              }
+            }
+            vertical={false}
+          >
             <RNSVGSvgView
               align="xMidYMid"
               bbHeight={48}
@@ -598,84 +621,117 @@ exports[`The Auth Verification component should render as disabled 1`] = `
           <View
             style={
               Object {
-                "paddingHorizontal": 16,
-                "paddingVertical": 16,
+                "flexDirection": "row",
               }
             }
           >
             <View
+              accessible={true}
+              clickable={true}
+              isTVSelectable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "flexDirection": "row",
+                  "opacity": 1,
                 }
               }
             >
               <View
-                accessible={true}
-                clickable={true}
-                isTVSelectable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
-                    "opacity": 1,
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "paddingHorizontal": 16,
+                    "paddingVertical": 16,
                   }
                 }
               >
-                <View
-                  borderRadius={48}
-                  iconPadding={9.6}
+                <RNSVGSvgView
+                  align="xMidYMid"
+                  bbHeight={24}
+                  bbWidth={24}
+                  height={24}
+                  meetOrSlice={0}
+                  minX={0}
+                  minY={0}
                   style={
-                    Object {
-                      "padding": 9.6,
-                      "paddingLeft": 0,
-                    }
+                    Array [
+                      Object {
+                        "backgroundColor": "transparent",
+                        "borderWidth": 0,
+                      },
+                      Object {
+                        "paddingRight": 0,
+                      },
+                      null,
+                      Object {
+                        "flex": 0,
+                        "height": 24,
+                        "width": 24,
+                      },
+                    ]
                   }
+                  vbHeight={24}
+                  vbWidth={24}
+                  width={24}
                 >
-                  <RNSVGSvgView
-                    align="xMidYMid"
-                    bbHeight={24}
-                    bbWidth={24}
-                    height={24}
-                    meetOrSlice={0}
-                    minX={0}
-                    minY={0}
-                    style={
+                  <RNSVGGroup
+                    fill={
                       Array [
-                        Object {
-                          "backgroundColor": "transparent",
-                          "borderWidth": 0,
-                        },
-                        undefined,
-                        Object {
-                          "opacity": 1,
-                        },
-                        Object {
-                          "flex": 0,
-                          "height": 24,
-                          "width": 24,
-                        },
+                        0,
+                        4278190080,
                       ]
                     }
-                    vbHeight={24}
-                    vbWidth={24}
-                    width={24}
+                    fillOpacity={1}
+                    fillRule={1}
+                    font={Object {}}
+                    matrix={
+                      Array [
+                        1,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                      ]
+                    }
+                    opacity={1}
+                    originX={0}
+                    originY={0}
+                    propList={Array []}
+                    rotation={0}
+                    scaleX={1}
+                    scaleY={1}
+                    skewX={0}
+                    skewY={0}
+                    stroke={null}
+                    strokeDasharray={null}
+                    strokeDashoffset={null}
+                    strokeLinecap={0}
+                    strokeLinejoin={0}
+                    strokeMiterlimit={4}
+                    strokeOpacity={1}
+                    strokeWidth={1}
+                    vectorEffect={0}
+                    x={0}
+                    y={0}
                   >
-                    <RNSVGGroup
+                    <RNSVGPath
+                      d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
                       fill={
                         Array [
                           0,
-                          4278190080,
+                          4279743874,
                         ]
                       }
                       fillOpacity={1}
                       fillRule={1}
-                      font={Object {}}
                       matrix={
                         Array [
                           1,
@@ -689,7 +745,11 @@ exports[`The Auth Verification component should render as disabled 1`] = `
                       opacity={1}
                       originX={0}
                       originY={0}
-                      propList={Array []}
+                      propList={
+                        Array [
+                          "fill",
+                        ]
+                      }
                       rotation={0}
                       scaleX={1}
                       scaleY={1}
@@ -706,57 +766,43 @@ exports[`The Auth Verification component should render as disabled 1`] = `
                       vectorEffect={0}
                       x={0}
                       y={0}
-                    >
-                      <RNSVGPath
-                        d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
-                        fill={
-                          Array [
-                            0,
-                            4279743874,
-                          ]
-                        }
-                        fillOpacity={1}
-                        fillRule={1}
-                        matrix={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                        opacity={1}
-                        originX={0}
-                        originY={0}
-                        propList={
-                          Array [
-                            "fill",
-                          ]
-                        }
-                        rotation={0}
-                        scaleX={1}
-                        scaleY={1}
-                        skewX={0}
-                        skewY={0}
-                        stroke={null}
-                        strokeDasharray={null}
-                        strokeDashoffset={null}
-                        strokeLinecap={0}
-                        strokeLinejoin={0}
-                        strokeMiterlimit={4}
-                        strokeOpacity={1}
-                        strokeWidth={1}
-                        vectorEffect={0}
-                        x={0}
-                        y={0}
-                      />
-                    </RNSVGGroup>
-                  </RNSVGSvgView>
-                </View>
+                    />
+                  </RNSVGGroup>
+                </RNSVGSvgView>
+                <Text
+                  style={
+                    Object {
+                      "color": "#303030",
+                      "fontFamily": "System",
+                      "fontSize": 14,
+                      "fontStyle": null,
+                      "fontWeight": null,
+                      "lineHeight": 20.16,
+                    }
+                  }
+                >
+                  <Text
+                    style={
+                      Object {
+                        "color": "#17B582",
+                      }
+                    }
+                  >
+                    Back
+                  </Text>
+                </Text>
               </View>
             </View>
+          </View>
+          <View
+            style={
+              Object {
+                "paddingHorizontal": 16,
+                "paddingVertical": 0,
+              }
+            }
+            vertical={false}
+          >
             <RNSVGSvgView
               align="xMidYMid"
               bbHeight={48}
@@ -1195,84 +1241,117 @@ exports[`The Auth Verification component should render in a loading state 1`] = 
           <View
             style={
               Object {
-                "paddingHorizontal": 16,
-                "paddingVertical": 16,
+                "flexDirection": "row",
               }
             }
           >
             <View
+              accessible={true}
+              clickable={true}
+              isTVSelectable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "flexDirection": "row",
+                  "opacity": 1,
                 }
               }
             >
               <View
-                accessible={true}
-                clickable={true}
-                isTVSelectable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
-                    "opacity": 1,
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "paddingHorizontal": 16,
+                    "paddingVertical": 16,
                   }
                 }
               >
-                <View
-                  borderRadius={48}
-                  iconPadding={9.6}
+                <RNSVGSvgView
+                  align="xMidYMid"
+                  bbHeight={24}
+                  bbWidth={24}
+                  height={24}
+                  meetOrSlice={0}
+                  minX={0}
+                  minY={0}
                   style={
-                    Object {
-                      "padding": 9.6,
-                      "paddingLeft": 0,
-                    }
+                    Array [
+                      Object {
+                        "backgroundColor": "transparent",
+                        "borderWidth": 0,
+                      },
+                      Object {
+                        "paddingRight": 0,
+                      },
+                      null,
+                      Object {
+                        "flex": 0,
+                        "height": 24,
+                        "width": 24,
+                      },
+                    ]
                   }
+                  vbHeight={24}
+                  vbWidth={24}
+                  width={24}
                 >
-                  <RNSVGSvgView
-                    align="xMidYMid"
-                    bbHeight={24}
-                    bbWidth={24}
-                    height={24}
-                    meetOrSlice={0}
-                    minX={0}
-                    minY={0}
-                    style={
+                  <RNSVGGroup
+                    fill={
                       Array [
-                        Object {
-                          "backgroundColor": "transparent",
-                          "borderWidth": 0,
-                        },
-                        undefined,
-                        Object {
-                          "opacity": 1,
-                        },
-                        Object {
-                          "flex": 0,
-                          "height": 24,
-                          "width": 24,
-                        },
+                        0,
+                        4278190080,
                       ]
                     }
-                    vbHeight={24}
-                    vbWidth={24}
-                    width={24}
+                    fillOpacity={1}
+                    fillRule={1}
+                    font={Object {}}
+                    matrix={
+                      Array [
+                        1,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                      ]
+                    }
+                    opacity={1}
+                    originX={0}
+                    originY={0}
+                    propList={Array []}
+                    rotation={0}
+                    scaleX={1}
+                    scaleY={1}
+                    skewX={0}
+                    skewY={0}
+                    stroke={null}
+                    strokeDasharray={null}
+                    strokeDashoffset={null}
+                    strokeLinecap={0}
+                    strokeLinejoin={0}
+                    strokeMiterlimit={4}
+                    strokeOpacity={1}
+                    strokeWidth={1}
+                    vectorEffect={0}
+                    x={0}
+                    y={0}
                   >
-                    <RNSVGGroup
+                    <RNSVGPath
+                      d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
                       fill={
                         Array [
                           0,
-                          4278190080,
+                          4279743874,
                         ]
                       }
                       fillOpacity={1}
                       fillRule={1}
-                      font={Object {}}
                       matrix={
                         Array [
                           1,
@@ -1286,7 +1365,11 @@ exports[`The Auth Verification component should render in a loading state 1`] = 
                       opacity={1}
                       originX={0}
                       originY={0}
-                      propList={Array []}
+                      propList={
+                        Array [
+                          "fill",
+                        ]
+                      }
                       rotation={0}
                       scaleX={1}
                       scaleY={1}
@@ -1303,57 +1386,43 @@ exports[`The Auth Verification component should render in a loading state 1`] = 
                       vectorEffect={0}
                       x={0}
                       y={0}
-                    >
-                      <RNSVGPath
-                        d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
-                        fill={
-                          Array [
-                            0,
-                            4279743874,
-                          ]
-                        }
-                        fillOpacity={1}
-                        fillRule={1}
-                        matrix={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                        opacity={1}
-                        originX={0}
-                        originY={0}
-                        propList={
-                          Array [
-                            "fill",
-                          ]
-                        }
-                        rotation={0}
-                        scaleX={1}
-                        scaleY={1}
-                        skewX={0}
-                        skewY={0}
-                        stroke={null}
-                        strokeDasharray={null}
-                        strokeDashoffset={null}
-                        strokeLinecap={0}
-                        strokeLinejoin={0}
-                        strokeMiterlimit={4}
-                        strokeOpacity={1}
-                        strokeWidth={1}
-                        vectorEffect={0}
-                        x={0}
-                        y={0}
-                      />
-                    </RNSVGGroup>
-                  </RNSVGSvgView>
-                </View>
+                    />
+                  </RNSVGGroup>
+                </RNSVGSvgView>
+                <Text
+                  style={
+                    Object {
+                      "color": "#303030",
+                      "fontFamily": "System",
+                      "fontSize": 14,
+                      "fontStyle": null,
+                      "fontWeight": null,
+                      "lineHeight": 20.16,
+                    }
+                  }
+                >
+                  <Text
+                    style={
+                      Object {
+                        "color": "#17B582",
+                      }
+                    }
+                  >
+                    Back
+                  </Text>
+                </Text>
               </View>
             </View>
+          </View>
+          <View
+            style={
+              Object {
+                "paddingHorizontal": 16,
+                "paddingVertical": 0,
+              }
+            }
+            vertical={false}
+          >
             <RNSVGSvgView
               align="xMidYMid"
               bbHeight={48}
@@ -1786,84 +1855,117 @@ exports[`The Auth Verification component should render in a next button 1`] = `
           <View
             style={
               Object {
-                "paddingHorizontal": 16,
-                "paddingVertical": 16,
+                "flexDirection": "row",
               }
             }
           >
             <View
+              accessible={true}
+              clickable={true}
+              isTVSelectable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "flexDirection": "row",
+                  "opacity": 1,
                 }
               }
             >
               <View
-                accessible={true}
-                clickable={true}
-                isTVSelectable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
-                    "opacity": 1,
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "paddingHorizontal": 16,
+                    "paddingVertical": 16,
                   }
                 }
               >
-                <View
-                  borderRadius={48}
-                  iconPadding={9.6}
+                <RNSVGSvgView
+                  align="xMidYMid"
+                  bbHeight={24}
+                  bbWidth={24}
+                  height={24}
+                  meetOrSlice={0}
+                  minX={0}
+                  minY={0}
                   style={
-                    Object {
-                      "padding": 9.6,
-                      "paddingLeft": 0,
-                    }
+                    Array [
+                      Object {
+                        "backgroundColor": "transparent",
+                        "borderWidth": 0,
+                      },
+                      Object {
+                        "paddingRight": 0,
+                      },
+                      null,
+                      Object {
+                        "flex": 0,
+                        "height": 24,
+                        "width": 24,
+                      },
+                    ]
                   }
+                  vbHeight={24}
+                  vbWidth={24}
+                  width={24}
                 >
-                  <RNSVGSvgView
-                    align="xMidYMid"
-                    bbHeight={24}
-                    bbWidth={24}
-                    height={24}
-                    meetOrSlice={0}
-                    minX={0}
-                    minY={0}
-                    style={
+                  <RNSVGGroup
+                    fill={
                       Array [
-                        Object {
-                          "backgroundColor": "transparent",
-                          "borderWidth": 0,
-                        },
-                        undefined,
-                        Object {
-                          "opacity": 1,
-                        },
-                        Object {
-                          "flex": 0,
-                          "height": 24,
-                          "width": 24,
-                        },
+                        0,
+                        4278190080,
                       ]
                     }
-                    vbHeight={24}
-                    vbWidth={24}
-                    width={24}
+                    fillOpacity={1}
+                    fillRule={1}
+                    font={Object {}}
+                    matrix={
+                      Array [
+                        1,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                      ]
+                    }
+                    opacity={1}
+                    originX={0}
+                    originY={0}
+                    propList={Array []}
+                    rotation={0}
+                    scaleX={1}
+                    scaleY={1}
+                    skewX={0}
+                    skewY={0}
+                    stroke={null}
+                    strokeDasharray={null}
+                    strokeDashoffset={null}
+                    strokeLinecap={0}
+                    strokeLinejoin={0}
+                    strokeMiterlimit={4}
+                    strokeOpacity={1}
+                    strokeWidth={1}
+                    vectorEffect={0}
+                    x={0}
+                    y={0}
                   >
-                    <RNSVGGroup
+                    <RNSVGPath
+                      d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
                       fill={
                         Array [
                           0,
-                          4278190080,
+                          4279743874,
                         ]
                       }
                       fillOpacity={1}
                       fillRule={1}
-                      font={Object {}}
                       matrix={
                         Array [
                           1,
@@ -1877,7 +1979,11 @@ exports[`The Auth Verification component should render in a next button 1`] = `
                       opacity={1}
                       originX={0}
                       originY={0}
-                      propList={Array []}
+                      propList={
+                        Array [
+                          "fill",
+                        ]
+                      }
                       rotation={0}
                       scaleX={1}
                       scaleY={1}
@@ -1894,57 +2000,43 @@ exports[`The Auth Verification component should render in a next button 1`] = `
                       vectorEffect={0}
                       x={0}
                       y={0}
-                    >
-                      <RNSVGPath
-                        d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
-                        fill={
-                          Array [
-                            0,
-                            4279743874,
-                          ]
-                        }
-                        fillOpacity={1}
-                        fillRule={1}
-                        matrix={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                        opacity={1}
-                        originX={0}
-                        originY={0}
-                        propList={
-                          Array [
-                            "fill",
-                          ]
-                        }
-                        rotation={0}
-                        scaleX={1}
-                        scaleY={1}
-                        skewX={0}
-                        skewY={0}
-                        stroke={null}
-                        strokeDasharray={null}
-                        strokeDashoffset={null}
-                        strokeLinecap={0}
-                        strokeLinejoin={0}
-                        strokeMiterlimit={4}
-                        strokeOpacity={1}
-                        strokeWidth={1}
-                        vectorEffect={0}
-                        x={0}
-                        y={0}
-                      />
-                    </RNSVGGroup>
-                  </RNSVGSvgView>
-                </View>
+                    />
+                  </RNSVGGroup>
+                </RNSVGSvgView>
+                <Text
+                  style={
+                    Object {
+                      "color": "#303030",
+                      "fontFamily": "System",
+                      "fontSize": 14,
+                      "fontStyle": null,
+                      "fontWeight": null,
+                      "lineHeight": 20.16,
+                    }
+                  }
+                >
+                  <Text
+                    style={
+                      Object {
+                        "color": "#17B582",
+                      }
+                    }
+                  >
+                    Back
+                  </Text>
+                </Text>
               </View>
             </View>
+          </View>
+          <View
+            style={
+              Object {
+                "paddingHorizontal": 16,
+                "paddingVertical": 0,
+              }
+            }
+            vertical={false}
+          >
             <RNSVGSvgView
               align="xMidYMid"
               bbHeight={48}
@@ -2383,84 +2475,117 @@ exports[`The Auth Verification component should render in an error state 1`] = `
           <View
             style={
               Object {
-                "paddingHorizontal": 16,
-                "paddingVertical": 16,
+                "flexDirection": "row",
               }
             }
           >
             <View
+              accessible={true}
+              clickable={true}
+              isTVSelectable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "flexDirection": "row",
+                  "opacity": 1,
                 }
               }
             >
               <View
-                accessible={true}
-                clickable={true}
-                isTVSelectable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
-                    "opacity": 1,
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "paddingHorizontal": 16,
+                    "paddingVertical": 16,
                   }
                 }
               >
-                <View
-                  borderRadius={48}
-                  iconPadding={9.6}
+                <RNSVGSvgView
+                  align="xMidYMid"
+                  bbHeight={24}
+                  bbWidth={24}
+                  height={24}
+                  meetOrSlice={0}
+                  minX={0}
+                  minY={0}
                   style={
-                    Object {
-                      "padding": 9.6,
-                      "paddingLeft": 0,
-                    }
+                    Array [
+                      Object {
+                        "backgroundColor": "transparent",
+                        "borderWidth": 0,
+                      },
+                      Object {
+                        "paddingRight": 0,
+                      },
+                      null,
+                      Object {
+                        "flex": 0,
+                        "height": 24,
+                        "width": 24,
+                      },
+                    ]
                   }
+                  vbHeight={24}
+                  vbWidth={24}
+                  width={24}
                 >
-                  <RNSVGSvgView
-                    align="xMidYMid"
-                    bbHeight={24}
-                    bbWidth={24}
-                    height={24}
-                    meetOrSlice={0}
-                    minX={0}
-                    minY={0}
-                    style={
+                  <RNSVGGroup
+                    fill={
                       Array [
-                        Object {
-                          "backgroundColor": "transparent",
-                          "borderWidth": 0,
-                        },
-                        undefined,
-                        Object {
-                          "opacity": 1,
-                        },
-                        Object {
-                          "flex": 0,
-                          "height": 24,
-                          "width": 24,
-                        },
+                        0,
+                        4278190080,
                       ]
                     }
-                    vbHeight={24}
-                    vbWidth={24}
-                    width={24}
+                    fillOpacity={1}
+                    fillRule={1}
+                    font={Object {}}
+                    matrix={
+                      Array [
+                        1,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                      ]
+                    }
+                    opacity={1}
+                    originX={0}
+                    originY={0}
+                    propList={Array []}
+                    rotation={0}
+                    scaleX={1}
+                    scaleY={1}
+                    skewX={0}
+                    skewY={0}
+                    stroke={null}
+                    strokeDasharray={null}
+                    strokeDashoffset={null}
+                    strokeLinecap={0}
+                    strokeLinejoin={0}
+                    strokeMiterlimit={4}
+                    strokeOpacity={1}
+                    strokeWidth={1}
+                    vectorEffect={0}
+                    x={0}
+                    y={0}
                   >
-                    <RNSVGGroup
+                    <RNSVGPath
+                      d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
                       fill={
                         Array [
                           0,
-                          4278190080,
+                          4279743874,
                         ]
                       }
                       fillOpacity={1}
                       fillRule={1}
-                      font={Object {}}
                       matrix={
                         Array [
                           1,
@@ -2474,7 +2599,11 @@ exports[`The Auth Verification component should render in an error state 1`] = `
                       opacity={1}
                       originX={0}
                       originY={0}
-                      propList={Array []}
+                      propList={
+                        Array [
+                          "fill",
+                        ]
+                      }
                       rotation={0}
                       scaleX={1}
                       scaleY={1}
@@ -2491,57 +2620,43 @@ exports[`The Auth Verification component should render in an error state 1`] = `
                       vectorEffect={0}
                       x={0}
                       y={0}
-                    >
-                      <RNSVGPath
-                        d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
-                        fill={
-                          Array [
-                            0,
-                            4279743874,
-                          ]
-                        }
-                        fillOpacity={1}
-                        fillRule={1}
-                        matrix={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                        opacity={1}
-                        originX={0}
-                        originY={0}
-                        propList={
-                          Array [
-                            "fill",
-                          ]
-                        }
-                        rotation={0}
-                        scaleX={1}
-                        scaleY={1}
-                        skewX={0}
-                        skewY={0}
-                        stroke={null}
-                        strokeDasharray={null}
-                        strokeDashoffset={null}
-                        strokeLinecap={0}
-                        strokeLinejoin={0}
-                        strokeMiterlimit={4}
-                        strokeOpacity={1}
-                        strokeWidth={1}
-                        vectorEffect={0}
-                        x={0}
-                        y={0}
-                      />
-                    </RNSVGGroup>
-                  </RNSVGSvgView>
-                </View>
+                    />
+                  </RNSVGGroup>
+                </RNSVGSvgView>
+                <Text
+                  style={
+                    Object {
+                      "color": "#303030",
+                      "fontFamily": "System",
+                      "fontSize": 14,
+                      "fontStyle": null,
+                      "fontWeight": null,
+                      "lineHeight": 20.16,
+                    }
+                  }
+                >
+                  <Text
+                    style={
+                      Object {
+                        "color": "#17B582",
+                      }
+                    }
+                  >
+                    Back
+                  </Text>
+                </Text>
               </View>
             </View>
+          </View>
+          <View
+            style={
+              Object {
+                "paddingHorizontal": 16,
+                "paddingVertical": 0,
+              }
+            }
+            vertical={false}
+          >
             <RNSVGSvgView
               align="xMidYMid"
               bbHeight={48}
@@ -2931,84 +3046,117 @@ exports[`The Auth Verification component should render with a custom confirmatio
           <View
             style={
               Object {
-                "paddingHorizontal": 16,
-                "paddingVertical": 16,
+                "flexDirection": "row",
               }
             }
           >
             <View
+              accessible={true}
+              clickable={true}
+              isTVSelectable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "flexDirection": "row",
+                  "opacity": 1,
                 }
               }
             >
               <View
-                accessible={true}
-                clickable={true}
-                isTVSelectable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
-                    "opacity": 1,
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "paddingHorizontal": 16,
+                    "paddingVertical": 16,
                   }
                 }
               >
-                <View
-                  borderRadius={48}
-                  iconPadding={9.6}
+                <RNSVGSvgView
+                  align="xMidYMid"
+                  bbHeight={24}
+                  bbWidth={24}
+                  height={24}
+                  meetOrSlice={0}
+                  minX={0}
+                  minY={0}
                   style={
-                    Object {
-                      "padding": 9.6,
-                      "paddingLeft": 0,
-                    }
+                    Array [
+                      Object {
+                        "backgroundColor": "transparent",
+                        "borderWidth": 0,
+                      },
+                      Object {
+                        "paddingRight": 0,
+                      },
+                      null,
+                      Object {
+                        "flex": 0,
+                        "height": 24,
+                        "width": 24,
+                      },
+                    ]
                   }
+                  vbHeight={24}
+                  vbWidth={24}
+                  width={24}
                 >
-                  <RNSVGSvgView
-                    align="xMidYMid"
-                    bbHeight={24}
-                    bbWidth={24}
-                    height={24}
-                    meetOrSlice={0}
-                    minX={0}
-                    minY={0}
-                    style={
+                  <RNSVGGroup
+                    fill={
                       Array [
-                        Object {
-                          "backgroundColor": "transparent",
-                          "borderWidth": 0,
-                        },
-                        undefined,
-                        Object {
-                          "opacity": 1,
-                        },
-                        Object {
-                          "flex": 0,
-                          "height": 24,
-                          "width": 24,
-                        },
+                        0,
+                        4278190080,
                       ]
                     }
-                    vbHeight={24}
-                    vbWidth={24}
-                    width={24}
+                    fillOpacity={1}
+                    fillRule={1}
+                    font={Object {}}
+                    matrix={
+                      Array [
+                        1,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                      ]
+                    }
+                    opacity={1}
+                    originX={0}
+                    originY={0}
+                    propList={Array []}
+                    rotation={0}
+                    scaleX={1}
+                    scaleY={1}
+                    skewX={0}
+                    skewY={0}
+                    stroke={null}
+                    strokeDasharray={null}
+                    strokeDashoffset={null}
+                    strokeLinecap={0}
+                    strokeLinejoin={0}
+                    strokeMiterlimit={4}
+                    strokeOpacity={1}
+                    strokeWidth={1}
+                    vectorEffect={0}
+                    x={0}
+                    y={0}
                   >
-                    <RNSVGGroup
+                    <RNSVGPath
+                      d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
                       fill={
                         Array [
                           0,
-                          4278190080,
+                          4279743874,
                         ]
                       }
                       fillOpacity={1}
                       fillRule={1}
-                      font={Object {}}
                       matrix={
                         Array [
                           1,
@@ -3022,7 +3170,11 @@ exports[`The Auth Verification component should render with a custom confirmatio
                       opacity={1}
                       originX={0}
                       originY={0}
-                      propList={Array []}
+                      propList={
+                        Array [
+                          "fill",
+                        ]
+                      }
                       rotation={0}
                       scaleX={1}
                       scaleY={1}
@@ -3039,57 +3191,43 @@ exports[`The Auth Verification component should render with a custom confirmatio
                       vectorEffect={0}
                       x={0}
                       y={0}
-                    >
-                      <RNSVGPath
-                        d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
-                        fill={
-                          Array [
-                            0,
-                            4279743874,
-                          ]
-                        }
-                        fillOpacity={1}
-                        fillRule={1}
-                        matrix={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                        opacity={1}
-                        originX={0}
-                        originY={0}
-                        propList={
-                          Array [
-                            "fill",
-                          ]
-                        }
-                        rotation={0}
-                        scaleX={1}
-                        scaleY={1}
-                        skewX={0}
-                        skewY={0}
-                        stroke={null}
-                        strokeDasharray={null}
-                        strokeDashoffset={null}
-                        strokeLinecap={0}
-                        strokeLinejoin={0}
-                        strokeMiterlimit={4}
-                        strokeOpacity={1}
-                        strokeWidth={1}
-                        vectorEffect={0}
-                        x={0}
-                        y={0}
-                      />
-                    </RNSVGGroup>
-                  </RNSVGSvgView>
-                </View>
+                    />
+                  </RNSVGGroup>
+                </RNSVGSvgView>
+                <Text
+                  style={
+                    Object {
+                      "color": "#303030",
+                      "fontFamily": "System",
+                      "fontSize": 14,
+                      "fontStyle": null,
+                      "fontWeight": null,
+                      "lineHeight": 20.16,
+                    }
+                  }
+                >
+                  <Text
+                    style={
+                      Object {
+                        "color": "#17B582",
+                      }
+                    }
+                  >
+                    Back
+                  </Text>
+                </Text>
               </View>
             </View>
+          </View>
+          <View
+            style={
+              Object {
+                "paddingHorizontal": 16,
+                "paddingVertical": 0,
+              }
+            }
+            vertical={false}
+          >
             <RNSVGSvgView
               align="xMidYMid"
               bbHeight={48}
@@ -3466,84 +3604,117 @@ exports[`The Auth Verification component should render with a value 1`] = `
           <View
             style={
               Object {
-                "paddingHorizontal": 16,
-                "paddingVertical": 16,
+                "flexDirection": "row",
               }
             }
           >
             <View
+              accessible={true}
+              clickable={true}
+              isTVSelectable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "flexDirection": "row",
+                  "opacity": 1,
                 }
               }
             >
               <View
-                accessible={true}
-                clickable={true}
-                isTVSelectable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
-                    "opacity": 1,
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "paddingHorizontal": 16,
+                    "paddingVertical": 16,
                   }
                 }
               >
-                <View
-                  borderRadius={48}
-                  iconPadding={9.6}
+                <RNSVGSvgView
+                  align="xMidYMid"
+                  bbHeight={24}
+                  bbWidth={24}
+                  height={24}
+                  meetOrSlice={0}
+                  minX={0}
+                  minY={0}
                   style={
-                    Object {
-                      "padding": 9.6,
-                      "paddingLeft": 0,
-                    }
+                    Array [
+                      Object {
+                        "backgroundColor": "transparent",
+                        "borderWidth": 0,
+                      },
+                      Object {
+                        "paddingRight": 0,
+                      },
+                      null,
+                      Object {
+                        "flex": 0,
+                        "height": 24,
+                        "width": 24,
+                      },
+                    ]
                   }
+                  vbHeight={24}
+                  vbWidth={24}
+                  width={24}
                 >
-                  <RNSVGSvgView
-                    align="xMidYMid"
-                    bbHeight={24}
-                    bbWidth={24}
-                    height={24}
-                    meetOrSlice={0}
-                    minX={0}
-                    minY={0}
-                    style={
+                  <RNSVGGroup
+                    fill={
                       Array [
-                        Object {
-                          "backgroundColor": "transparent",
-                          "borderWidth": 0,
-                        },
-                        undefined,
-                        Object {
-                          "opacity": 1,
-                        },
-                        Object {
-                          "flex": 0,
-                          "height": 24,
-                          "width": 24,
-                        },
+                        0,
+                        4278190080,
                       ]
                     }
-                    vbHeight={24}
-                    vbWidth={24}
-                    width={24}
+                    fillOpacity={1}
+                    fillRule={1}
+                    font={Object {}}
+                    matrix={
+                      Array [
+                        1,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                      ]
+                    }
+                    opacity={1}
+                    originX={0}
+                    originY={0}
+                    propList={Array []}
+                    rotation={0}
+                    scaleX={1}
+                    scaleY={1}
+                    skewX={0}
+                    skewY={0}
+                    stroke={null}
+                    strokeDasharray={null}
+                    strokeDashoffset={null}
+                    strokeLinecap={0}
+                    strokeLinejoin={0}
+                    strokeMiterlimit={4}
+                    strokeOpacity={1}
+                    strokeWidth={1}
+                    vectorEffect={0}
+                    x={0}
+                    y={0}
                   >
-                    <RNSVGGroup
+                    <RNSVGPath
+                      d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
                       fill={
                         Array [
                           0,
-                          4278190080,
+                          4279743874,
                         ]
                       }
                       fillOpacity={1}
                       fillRule={1}
-                      font={Object {}}
                       matrix={
                         Array [
                           1,
@@ -3557,7 +3728,11 @@ exports[`The Auth Verification component should render with a value 1`] = `
                       opacity={1}
                       originX={0}
                       originY={0}
-                      propList={Array []}
+                      propList={
+                        Array [
+                          "fill",
+                        ]
+                      }
                       rotation={0}
                       scaleX={1}
                       scaleY={1}
@@ -3574,57 +3749,43 @@ exports[`The Auth Verification component should render with a value 1`] = `
                       vectorEffect={0}
                       x={0}
                       y={0}
-                    >
-                      <RNSVGPath
-                        d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
-                        fill={
-                          Array [
-                            0,
-                            4279743874,
-                          ]
-                        }
-                        fillOpacity={1}
-                        fillRule={1}
-                        matrix={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                        opacity={1}
-                        originX={0}
-                        originY={0}
-                        propList={
-                          Array [
-                            "fill",
-                          ]
-                        }
-                        rotation={0}
-                        scaleX={1}
-                        scaleY={1}
-                        skewX={0}
-                        skewY={0}
-                        stroke={null}
-                        strokeDasharray={null}
-                        strokeDashoffset={null}
-                        strokeLinecap={0}
-                        strokeLinejoin={0}
-                        strokeMiterlimit={4}
-                        strokeOpacity={1}
-                        strokeWidth={1}
-                        vectorEffect={0}
-                        x={0}
-                        y={0}
-                      />
-                    </RNSVGGroup>
-                  </RNSVGSvgView>
-                </View>
+                    />
+                  </RNSVGGroup>
+                </RNSVGSvgView>
+                <Text
+                  style={
+                    Object {
+                      "color": "#303030",
+                      "fontFamily": "System",
+                      "fontSize": 14,
+                      "fontStyle": null,
+                      "fontWeight": null,
+                      "lineHeight": 20.16,
+                    }
+                  }
+                >
+                  <Text
+                    style={
+                      Object {
+                        "color": "#17B582",
+                      }
+                    }
+                  >
+                    Back
+                  </Text>
+                </Text>
               </View>
             </View>
+          </View>
+          <View
+            style={
+              Object {
+                "paddingHorizontal": 16,
+                "paddingVertical": 0,
+              }
+            }
+            vertical={false}
+          >
             <RNSVGSvgView
               align="xMidYMid"
               bbHeight={48}
@@ -4002,84 +4163,117 @@ exports[`The Auth Verification component should render with custom confirmationT
           <View
             style={
               Object {
-                "paddingHorizontal": 16,
-                "paddingVertical": 16,
+                "flexDirection": "row",
               }
             }
           >
             <View
+              accessible={true}
+              clickable={true}
+              isTVSelectable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "flexDirection": "row",
+                  "opacity": 1,
                 }
               }
             >
               <View
-                accessible={true}
-                clickable={true}
-                isTVSelectable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
-                    "opacity": 1,
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "paddingHorizontal": 16,
+                    "paddingVertical": 16,
                   }
                 }
               >
-                <View
-                  borderRadius={48}
-                  iconPadding={9.6}
+                <RNSVGSvgView
+                  align="xMidYMid"
+                  bbHeight={24}
+                  bbWidth={24}
+                  height={24}
+                  meetOrSlice={0}
+                  minX={0}
+                  minY={0}
                   style={
-                    Object {
-                      "padding": 9.6,
-                      "paddingLeft": 0,
-                    }
+                    Array [
+                      Object {
+                        "backgroundColor": "transparent",
+                        "borderWidth": 0,
+                      },
+                      Object {
+                        "paddingRight": 0,
+                      },
+                      null,
+                      Object {
+                        "flex": 0,
+                        "height": 24,
+                        "width": 24,
+                      },
+                    ]
                   }
+                  vbHeight={24}
+                  vbWidth={24}
+                  width={24}
                 >
-                  <RNSVGSvgView
-                    align="xMidYMid"
-                    bbHeight={24}
-                    bbWidth={24}
-                    height={24}
-                    meetOrSlice={0}
-                    minX={0}
-                    minY={0}
-                    style={
+                  <RNSVGGroup
+                    fill={
                       Array [
-                        Object {
-                          "backgroundColor": "transparent",
-                          "borderWidth": 0,
-                        },
-                        undefined,
-                        Object {
-                          "opacity": 1,
-                        },
-                        Object {
-                          "flex": 0,
-                          "height": 24,
-                          "width": 24,
-                        },
+                        0,
+                        4278190080,
                       ]
                     }
-                    vbHeight={24}
-                    vbWidth={24}
-                    width={24}
+                    fillOpacity={1}
+                    fillRule={1}
+                    font={Object {}}
+                    matrix={
+                      Array [
+                        1,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                      ]
+                    }
+                    opacity={1}
+                    originX={0}
+                    originY={0}
+                    propList={Array []}
+                    rotation={0}
+                    scaleX={1}
+                    scaleY={1}
+                    skewX={0}
+                    skewY={0}
+                    stroke={null}
+                    strokeDasharray={null}
+                    strokeDashoffset={null}
+                    strokeLinecap={0}
+                    strokeLinejoin={0}
+                    strokeMiterlimit={4}
+                    strokeOpacity={1}
+                    strokeWidth={1}
+                    vectorEffect={0}
+                    x={0}
+                    y={0}
                   >
-                    <RNSVGGroup
+                    <RNSVGPath
+                      d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
                       fill={
                         Array [
                           0,
-                          4278190080,
+                          4279743874,
                         ]
                       }
                       fillOpacity={1}
                       fillRule={1}
-                      font={Object {}}
                       matrix={
                         Array [
                           1,
@@ -4093,7 +4287,11 @@ exports[`The Auth Verification component should render with custom confirmationT
                       opacity={1}
                       originX={0}
                       originY={0}
-                      propList={Array []}
+                      propList={
+                        Array [
+                          "fill",
+                        ]
+                      }
                       rotation={0}
                       scaleX={1}
                       scaleY={1}
@@ -4110,57 +4308,43 @@ exports[`The Auth Verification component should render with custom confirmationT
                       vectorEffect={0}
                       x={0}
                       y={0}
-                    >
-                      <RNSVGPath
-                        d="M14.35 21L6.2 12.46c-.26-.28-.26-.64 0-.92L14.34 3l1.65.9L8.27 12 16 20.1l-1.65.9z"
-                        fill={
-                          Array [
-                            0,
-                            4279743874,
-                          ]
-                        }
-                        fillOpacity={1}
-                        fillRule={1}
-                        matrix={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                        opacity={1}
-                        originX={0}
-                        originY={0}
-                        propList={
-                          Array [
-                            "fill",
-                          ]
-                        }
-                        rotation={0}
-                        scaleX={1}
-                        scaleY={1}
-                        skewX={0}
-                        skewY={0}
-                        stroke={null}
-                        strokeDasharray={null}
-                        strokeDashoffset={null}
-                        strokeLinecap={0}
-                        strokeLinejoin={0}
-                        strokeMiterlimit={4}
-                        strokeOpacity={1}
-                        strokeWidth={1}
-                        vectorEffect={0}
-                        x={0}
-                        y={0}
-                      />
-                    </RNSVGGroup>
-                  </RNSVGSvgView>
-                </View>
+                    />
+                  </RNSVGGroup>
+                </RNSVGSvgView>
+                <Text
+                  style={
+                    Object {
+                      "color": "#303030",
+                      "fontFamily": "System",
+                      "fontSize": 14,
+                      "fontStyle": null,
+                      "fontWeight": null,
+                      "lineHeight": 20.16,
+                    }
+                  }
+                >
+                  <Text
+                    style={
+                      Object {
+                        "color": "#17B582",
+                      }
+                    }
+                  >
+                    Back
+                  </Text>
+                </Text>
               </View>
             </View>
+          </View>
+          <View
+            style={
+              Object {
+                "paddingHorizontal": 16,
+                "paddingVertical": 0,
+              }
+            }
+            vertical={false}
+          >
             <RNSVGSvgView
               align="xMidYMid"
               bbHeight={48}

--- a/packages/apollos-ui-auth/src/styles.js
+++ b/packages/apollos-ui-auth/src/styles.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { SafeAreaView } from 'react-navigation';
 import { compose, withProps } from 'recompose';
-import { View } from 'react-native';
 import {
   styled,
   Button,
@@ -9,8 +8,6 @@ import {
   Icon,
   H2,
   H5,
-  PaddedView,
-  Touchable,
 } from '@apollosproject/ui-kit';
 
 const FlexedSafeAreaView = compose(
@@ -43,41 +40,4 @@ const NextButton = styled({}, 'ui-auth.NextButton')((props) => (
   <Button type={'primary'} pill={false} {...props} />
 ));
 
-const SuppressingView = styled(
-  {
-    flexDirection: 'row',
-  },
-  'ui-auth.SuppressingView'
-)(View);
-
-const BackButtonTouchable = withTheme(({ theme }) => ({
-  borderRadius: theme.sizing.baseUnit,
-}))(Touchable);
-
-const BackButtonWrapper = styled(
-  {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  'ui-auth.BackButtonWrapper'
-)(PaddedView);
-
-const BackButtonIcon = withTheme(({ theme }) => ({
-  fill: theme.colors.action.secondary,
-  size: theme.sizing.baseUnit * 1.5,
-  style: {
-    paddingRight: 0,
-  },
-}))(Icon);
-
-export {
-  FlexedSafeAreaView,
-  BrandIcon,
-  TitleText,
-  PromptText,
-  SuppressingView,
-  BackButtonTouchable,
-  BackButtonWrapper,
-  BackButtonIcon,
-  NextButton,
-};
+export { FlexedSafeAreaView, BrandIcon, TitleText, PromptText, NextButton };

--- a/packages/apollos-ui-auth/src/styles.js
+++ b/packages/apollos-ui-auth/src/styles.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { SafeAreaView } from 'react-navigation';
 import { compose, withProps } from 'recompose';
+import { View } from 'react-native';
 import {
   styled,
   Button,
@@ -8,6 +9,8 @@ import {
   Icon,
   H2,
   H5,
+  PaddedView,
+  Touchable,
 } from '@apollosproject/ui-kit';
 
 const FlexedSafeAreaView = compose(
@@ -40,4 +43,41 @@ const NextButton = styled({}, 'ui-auth.NextButton')((props) => (
   <Button type={'primary'} pill={false} {...props} />
 ));
 
-export { FlexedSafeAreaView, BrandIcon, TitleText, PromptText, NextButton };
+const SuppressingView = styled(
+  {
+    flexDirection: 'row',
+  },
+  'ui-auth.SuppressingView'
+)(View);
+
+const BackButtonTouchable = withTheme(({ theme }) => ({
+  borderRadius: theme.sizing.baseUnit,
+}))(Touchable);
+
+const BackButtonWrapper = styled(
+  {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  'ui-auth.BackButtonWrapper'
+)(PaddedView);
+
+const BackButtonIcon = withTheme(({ theme }) => ({
+  fill: theme.colors.action.secondary,
+  size: theme.sizing.baseUnit * 1.5,
+  style: {
+    paddingRight: 0,
+  },
+}))(Icon);
+
+export {
+  FlexedSafeAreaView,
+  BrandIcon,
+  TitleText,
+  PromptText,
+  SuppressingView,
+  BackButtonTouchable,
+  BackButtonWrapper,
+  BackButtonIcon,
+  NextButton,
+};


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

The back button on the SMS Verification screen filled the full width of the screen. This PR adds a view to suppress the width of the BackButton component.

### What design trade-offs/decisions were made?

### How do I test this PR?

1. On the login screen, enter your phone number
2. Horizontally aligned with the back button at the midpoint of the width of the screen, tap; nothing should happen

### What automated tests did you write?

## SCREENSHOTS

![Screen Recording 2019-12-02 at 10 21 AM](https://user-images.githubusercontent.com/29125070/69971180-80dd1a80-14ed-11ea-966f-1140c53b7f93.gif)

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
