### PR TITLE
Remove second give link

### DIFF
--- a/packages/apolloschurchapp/src/tabs/connect/ActionTable/index.js
+++ b/packages/apolloschurchapp/src/tabs/connect/ActionTable/index.js
@@ -62,15 +62,6 @@ const ActionTable = () => (
               <CellIcon name="arrow-next" />
             </Cell>
           </Touchable>
-          <Divider />
-          <Touchable
-            onPress={() => openUrl('https://apollosrock.newspring.cc/page/186')}
-          >
-            <Cell>
-              <CellText>I would like to give</CellText>
-              <CellIcon name="arrow-next" />
-            </Cell>
-          </Touchable>
         </TableView>
         <TableView>
           <Touchable


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Easy one! Just removes the second "give" link on the connect screen.

### What design trade-offs/decisions were made?

### How do I test this PR?

1. Go to the connect screen and fail to find a second link :D

### What automated tests did you write?

## SCREENSHOTS

<img width="570" alt="Screen Shot 2019-12-02 at 10 35 31 AM" src="https://user-images.githubusercontent.com/29125070/69972376-7d4a9300-14ef-11ea-9516-9332b9d90db5.png">

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
