### PR TITLE
Use calendar spinner view on android by default

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,10 +13,3 @@ pull_request_rules:
       - merged
     actions:
       delete_head_branch: {}
-  - name: automatic update HEAD
-    conditions:
-      - "#approved-reviews-by>=1"
-    actions:
-      merge:
-        method: merge
-        strict: true

--- a/packages/apollos-ui-kit/package.json
+++ b/packages/apollos-ui-kit/package.json
@@ -48,14 +48,14 @@
     "react-native": "*",
     "react-native-gesture-handler": "*",
     "react-native-linear-gradient": "*",
-    "react-native-svg": "*"
+    "react-native-svg": "*",
+    "react-native-modal-datetime-picker": "*"
   },
   "dependencies": {
     "color": "^3.1.0",
     "lodash": "^4.17.11",
     "moment": "^2.24.0",
     "numeral": "^2.0.6",
-    "react-native-modal-datetime-picker": "6.0.0",
     "react-native-safe-area-context": "^0.3.6",
     "react-native-tab-view": "1.0.2",
     "recompose": "^0.30.0",

--- a/packages/apollos-ui-kit/package.json
+++ b/packages/apollos-ui-kit/package.json
@@ -59,7 +59,8 @@
     "react-native-safe-area-context": "^0.3.6",
     "react-native-tab-view": "1.0.2",
     "recompose": "^0.30.0",
-    "rn-placeholder": "1.2.0"
+    "rn-placeholder": "1.2.0",
+    "react-native-modal-datetime-picker": "7.6.0"
   },
   "devDependencies": {
     "jest": "24.8.0",

--- a/packages/apollos-ui-kit/src/inputs/DateInput/DateInput.stories.js
+++ b/packages/apollos-ui-kit/src/inputs/DateInput/DateInput.stories.js
@@ -18,4 +18,7 @@ storiesOf('ui-kit/Inputs/DateInput', module)
       </CenteredView>
     </View>
   ))
-  .add('default', () => <DateInput />);
+  .add('default', () => <DateInput />)
+  .add('displayValue', () => (
+    <DateInput displayValue={moment.utc('1/1/2015').format('YYYY/MM/DD')} />
+  ));

--- a/packages/apollos-ui-kit/src/inputs/DateInput/DateInput.stories.js
+++ b/packages/apollos-ui-kit/src/inputs/DateInput/DateInput.stories.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { storiesOf } from '@apollosproject/ui-storybook';
+import { View } from 'react-native';
+import moment from 'moment';
+
+import CenteredView from '../../CenteredView';
+import PaddedView from '../../PaddedView';
+
+import DateInput from '.';
+
+storiesOf('ui-kit/Inputs/DateInput', module)
+  .addDecorator((story) => (
+    // eslint-disable-next-line react-native/no-inline-styles,react-native/no-color-literals
+    <View style={{ backgroundColor: 'white', flex: 1 }}>
+      <CenteredView>
+        {/* eslint-disable-next-line react-native/no-inline-styles */}
+        <PaddedView style={{ alignSelf: 'stretch' }}>{story()}</PaddedView>
+      </CenteredView>
+    </View>
+  ))
+  .add('default', () => (
+    <DateInput
+      value={moment.utc('1/1/2015').toDate()}
+      maximumDate={moment.utc('1/1/2015').toDate()}
+    />
+  ));

--- a/packages/apollos-ui-kit/src/inputs/DateInput/DateInput.stories.js
+++ b/packages/apollos-ui-kit/src/inputs/DateInput/DateInput.stories.js
@@ -21,6 +21,6 @@ storiesOf('ui-kit/Inputs/DateInput', module)
   .add('default', () => <DateInput />)
   .add('displayValue', () => (
     <DateInput displayValue={moment.utc('1/1/2015').format('YYYY/MM/DD')} />
-  ));
   ))
   .add('placeholder', () => <DateInput placeholder={'mm/dd/yyyy'} />)
+  .add('label', () => <DateInput label={'Date Label'} />);

--- a/packages/apollos-ui-kit/src/inputs/DateInput/DateInput.stories.js
+++ b/packages/apollos-ui-kit/src/inputs/DateInput/DateInput.stories.js
@@ -23,4 +23,5 @@ storiesOf('ui-kit/Inputs/DateInput', module)
     <DateInput displayValue={moment.utc('1/1/2015').format('YYYY/MM/DD')} />
   ))
   .add('placeholder', () => <DateInput placeholder={'mm/dd/yyyy'} />)
-  .add('label', () => <DateInput label={'Date Label'} />);
+  .add('label', () => <DateInput label={'Date Label'} />)
+  .add('error', () => <DateInput error={'Danger Will Robinson'} />);

--- a/packages/apollos-ui-kit/src/inputs/DateInput/DateInput.stories.js
+++ b/packages/apollos-ui-kit/src/inputs/DateInput/DateInput.stories.js
@@ -18,9 +18,4 @@ storiesOf('ui-kit/Inputs/DateInput', module)
       </CenteredView>
     </View>
   ))
-  .add('default', () => (
-    <DateInput
-      value={moment.utc('1/1/2015').toDate()}
-      maximumDate={moment.utc('1/1/2015').toDate()}
-    />
-  ));
+  .add('default', () => <DateInput />);

--- a/packages/apollos-ui-kit/src/inputs/DateInput/DateInput.stories.js
+++ b/packages/apollos-ui-kit/src/inputs/DateInput/DateInput.stories.js
@@ -22,3 +22,5 @@ storiesOf('ui-kit/Inputs/DateInput', module)
   .add('displayValue', () => (
     <DateInput displayValue={moment.utc('1/1/2015').format('YYYY/MM/DD')} />
   ));
+  ))
+  .add('placeholder', () => <DateInput placeholder={'mm/dd/yyyy'} />)

--- a/packages/apollos-ui-kit/src/inputs/DateInput/DateInput.tests.js
+++ b/packages/apollos-ui-kit/src/inputs/DateInput/DateInput.tests.js
@@ -6,7 +6,17 @@ import Providers from '../../Providers';
 
 import DateInput from '.';
 
+let realDateNow;
+
 describe('The DateInput component', () => {
+  beforeAll(() => {
+    realDateNow = Date.now.bind(global.Date);
+    const dateNowStub = jest.fn(() => 1530518207007);
+    global.Date.now = dateNowStub;
+  });
+  afterAll(() => {
+    global.Date.now = realDateNow;
+  });
   it('should render', () => {
     const tree = renderer.create(
       <Providers>

--- a/packages/apollos-ui-kit/src/inputs/DateInput/__snapshots__/DateInput.tests.js.snap
+++ b/packages/apollos-ui-kit/src/inputs/DateInput/__snapshots__/DateInput.tests.js.snap
@@ -53,7 +53,10 @@ exports[`The DateInput component should render 1`] = `
     hardwareAccelerated={false}
     hideModalContentWhileAnimating={false}
     onModalHide={[Function]}
+    onModalWillHide={[Function]}
+    onModalWillShow={[Function]}
     onRequestClose={[Function]}
+    scrollHorizontal={false}
     scrollOffset={0}
     scrollOffsetMax={0}
     scrollTo={null}
@@ -94,7 +97,10 @@ exports[`The DateInput component should render 1`] = `
     <View
       hideModalContentWhileAnimating={false}
       onModalHide={[Function]}
+      onModalWillHide={[Function]}
+      onModalWillShow={[Function]}
       pointerEvents="box-none"
+      scrollHorizontal={false}
       scrollOffset={0}
       scrollOffsetMax={0}
       scrollTo={null}
@@ -122,10 +128,12 @@ exports[`The DateInput component should render 1`] = `
         style={
           Array [
             Object {
-              "backgroundColor": "white",
               "borderRadius": 13,
               "marginBottom": 8,
               "overflow": "hidden",
+            },
+            Object {
+              "backgroundColor": "white",
             },
             undefined,
           ]
@@ -227,13 +235,18 @@ exports[`The DateInput component should render 1`] = `
         onResponderTerminationRequest={[Function]}
         onStartShouldSetResponder={[Function]}
         style={
-          Object {
-            "backgroundColor": "white",
-            "borderRadius": 13,
-            "height": 57,
-            "justifyContent": "center",
-            "marginBottom": 0,
-          }
+          Array [
+            Object {
+              "borderRadius": 13,
+              "height": 57,
+              "justifyContent": "center",
+              "marginBottom": 0,
+            },
+            Object {
+              "backgroundColor": "white",
+            },
+            undefined,
+          ]
         }
       >
         <Text
@@ -329,7 +342,10 @@ exports[`The DateInput component should render with a displayValue 1`] = `
     hardwareAccelerated={false}
     hideModalContentWhileAnimating={false}
     onModalHide={[Function]}
+    onModalWillHide={[Function]}
+    onModalWillShow={[Function]}
     onRequestClose={[Function]}
+    scrollHorizontal={false}
     scrollOffset={0}
     scrollOffsetMax={0}
     scrollTo={null}
@@ -370,7 +386,10 @@ exports[`The DateInput component should render with a displayValue 1`] = `
     <View
       hideModalContentWhileAnimating={false}
       onModalHide={[Function]}
+      onModalWillHide={[Function]}
+      onModalWillShow={[Function]}
       pointerEvents="box-none"
+      scrollHorizontal={false}
       scrollOffset={0}
       scrollOffsetMax={0}
       scrollTo={null}
@@ -398,10 +417,12 @@ exports[`The DateInput component should render with a displayValue 1`] = `
         style={
           Array [
             Object {
-              "backgroundColor": "white",
               "borderRadius": 13,
               "marginBottom": 8,
               "overflow": "hidden",
+            },
+            Object {
+              "backgroundColor": "white",
             },
             undefined,
           ]
@@ -503,13 +524,18 @@ exports[`The DateInput component should render with a displayValue 1`] = `
         onResponderTerminationRequest={[Function]}
         onStartShouldSetResponder={[Function]}
         style={
-          Object {
-            "backgroundColor": "white",
-            "borderRadius": 13,
-            "height": 57,
-            "justifyContent": "center",
-            "marginBottom": 0,
-          }
+          Array [
+            Object {
+              "borderRadius": 13,
+              "height": 57,
+              "justifyContent": "center",
+              "marginBottom": 0,
+            },
+            Object {
+              "backgroundColor": "white",
+            },
+            undefined,
+          ]
         }
       >
         <Text
@@ -642,7 +668,10 @@ exports[`The DateInput component should render with a label 1`] = `
     hardwareAccelerated={false}
     hideModalContentWhileAnimating={false}
     onModalHide={[Function]}
+    onModalWillHide={[Function]}
+    onModalWillShow={[Function]}
     onRequestClose={[Function]}
+    scrollHorizontal={false}
     scrollOffset={0}
     scrollOffsetMax={0}
     scrollTo={null}
@@ -683,7 +712,10 @@ exports[`The DateInput component should render with a label 1`] = `
     <View
       hideModalContentWhileAnimating={false}
       onModalHide={[Function]}
+      onModalWillHide={[Function]}
+      onModalWillShow={[Function]}
       pointerEvents="box-none"
+      scrollHorizontal={false}
       scrollOffset={0}
       scrollOffsetMax={0}
       scrollTo={null}
@@ -711,10 +743,12 @@ exports[`The DateInput component should render with a label 1`] = `
         style={
           Array [
             Object {
-              "backgroundColor": "white",
               "borderRadius": 13,
               "marginBottom": 8,
               "overflow": "hidden",
+            },
+            Object {
+              "backgroundColor": "white",
             },
             undefined,
           ]
@@ -816,13 +850,18 @@ exports[`The DateInput component should render with a label 1`] = `
         onResponderTerminationRequest={[Function]}
         onStartShouldSetResponder={[Function]}
         style={
-          Object {
-            "backgroundColor": "white",
-            "borderRadius": 13,
-            "height": 57,
-            "justifyContent": "center",
-            "marginBottom": 0,
-          }
+          Array [
+            Object {
+              "borderRadius": 13,
+              "height": 57,
+              "justifyContent": "center",
+              "marginBottom": 0,
+            },
+            Object {
+              "backgroundColor": "white",
+            },
+            undefined,
+          ]
         }
       >
         <Text
@@ -957,7 +996,10 @@ exports[`The DateInput component should render with a placeholder 1`] = `
     hardwareAccelerated={false}
     hideModalContentWhileAnimating={false}
     onModalHide={[Function]}
+    onModalWillHide={[Function]}
+    onModalWillShow={[Function]}
     onRequestClose={[Function]}
+    scrollHorizontal={false}
     scrollOffset={0}
     scrollOffsetMax={0}
     scrollTo={null}
@@ -998,7 +1040,10 @@ exports[`The DateInput component should render with a placeholder 1`] = `
     <View
       hideModalContentWhileAnimating={false}
       onModalHide={[Function]}
+      onModalWillHide={[Function]}
+      onModalWillShow={[Function]}
       pointerEvents="box-none"
+      scrollHorizontal={false}
       scrollOffset={0}
       scrollOffsetMax={0}
       scrollTo={null}
@@ -1026,10 +1071,12 @@ exports[`The DateInput component should render with a placeholder 1`] = `
         style={
           Array [
             Object {
-              "backgroundColor": "white",
               "borderRadius": 13,
               "marginBottom": 8,
               "overflow": "hidden",
+            },
+            Object {
+              "backgroundColor": "white",
             },
             undefined,
           ]
@@ -1131,13 +1178,18 @@ exports[`The DateInput component should render with a placeholder 1`] = `
         onResponderTerminationRequest={[Function]}
         onStartShouldSetResponder={[Function]}
         style={
-          Object {
-            "backgroundColor": "white",
-            "borderRadius": 13,
-            "height": 57,
-            "justifyContent": "center",
-            "marginBottom": 0,
-          }
+          Array [
+            Object {
+              "borderRadius": 13,
+              "height": 57,
+              "justifyContent": "center",
+              "marginBottom": 0,
+            },
+            Object {
+              "backgroundColor": "white",
+            },
+            undefined,
+          ]
         }
       >
         <Text
@@ -1253,7 +1305,10 @@ exports[`The DateInput component should render with an error 1`] = `
     hardwareAccelerated={false}
     hideModalContentWhileAnimating={false}
     onModalHide={[Function]}
+    onModalWillHide={[Function]}
+    onModalWillShow={[Function]}
     onRequestClose={[Function]}
+    scrollHorizontal={false}
     scrollOffset={0}
     scrollOffsetMax={0}
     scrollTo={null}
@@ -1294,7 +1349,10 @@ exports[`The DateInput component should render with an error 1`] = `
     <View
       hideModalContentWhileAnimating={false}
       onModalHide={[Function]}
+      onModalWillHide={[Function]}
+      onModalWillShow={[Function]}
       pointerEvents="box-none"
+      scrollHorizontal={false}
       scrollOffset={0}
       scrollOffsetMax={0}
       scrollTo={null}
@@ -1322,10 +1380,12 @@ exports[`The DateInput component should render with an error 1`] = `
         style={
           Array [
             Object {
-              "backgroundColor": "white",
               "borderRadius": 13,
               "marginBottom": 8,
               "overflow": "hidden",
+            },
+            Object {
+              "backgroundColor": "white",
             },
             undefined,
           ]
@@ -1427,13 +1487,18 @@ exports[`The DateInput component should render with an error 1`] = `
         onResponderTerminationRequest={[Function]}
         onStartShouldSetResponder={[Function]}
         style={
-          Object {
-            "backgroundColor": "white",
-            "borderRadius": 13,
-            "height": 57,
-            "justifyContent": "center",
-            "marginBottom": 0,
-          }
+          Array [
+            Object {
+              "borderRadius": 13,
+              "height": 57,
+              "justifyContent": "center",
+              "marginBottom": 0,
+            },
+            Object {
+              "backgroundColor": "white",
+            },
+            undefined,
+          ]
         }
       >
         <Text

--- a/packages/apollos-ui-kit/src/inputs/DateInput/index.js
+++ b/packages/apollos-ui-kit/src/inputs/DateInput/index.js
@@ -45,9 +45,16 @@ class DateInput extends PureComponent {
     this.handleClose();
   };
 
+  getValidateDateValue = (date = new Date()) => {
+    let validDate = date;
+    if (typeof validDate === 'string') {
+      validDate = moment(date).toDate();
+    }
+
+    return validDate;
+  };
+
   render() {
-    let date = this.props.value;
-    if (typeof date === 'string') date = moment(date).toDate();
     return (
       <InputWrapper>
         <StyledChip
@@ -59,13 +66,13 @@ class DateInput extends PureComponent {
           onPress={this.handleOpen}
         />
         <DateTimePicker
-          value={date || new Date()}
+          date={this.getValidateDateValue(this.props.value)}
+          datePickerModeAndroid={'spinner'}
+          isVisible={this.state.isVisible}
+          mode={'date'}
           onConfirm={this.handleConfirm}
           onCancel={this.handleClose}
-          isVisible={this.state.isVisible}
           maximumDate={this.props.maximumDate || new Date(Date.now())} // Using Date.now so we have something to mock in the tests
-          datePickerModeAndroid="spinner"
-          mode="date"
         />
         {this.props.displayValue || this.props.placeholder ? (
           <FloatingLabel animation={new Animated.Value(1)}>

--- a/packages/apollos-ui-kit/src/inputs/DateInput/index.js
+++ b/packages/apollos-ui-kit/src/inputs/DateInput/index.js
@@ -23,7 +23,7 @@ class DateInput extends PureComponent {
     onChangeText: PropTypes.func,
     onBlur: PropTypes.func,
     error: PropTypes.any, // eslint-disable-line
-    maximumDate: PropTypes.string,
+    maximumDate: PropTypes.any, // eslint-disable-line
   };
 
   state = {

--- a/packages/apollos-ui-kit/src/inputs/DateInput/index.js
+++ b/packages/apollos-ui-kit/src/inputs/DateInput/index.js
@@ -45,15 +45,6 @@ class DateInput extends PureComponent {
     this.handleClose();
   };
 
-  getValidateDateValue = (date) => {
-    let validDate = date;
-    if (validDate !== null) {
-      validDate = moment(date).toDate();
-    }
-
-    return validDate;
-  };
-
   render() {
     return (
       <InputWrapper>

--- a/packages/apollos-ui-kit/src/inputs/DateInput/index.js
+++ b/packages/apollos-ui-kit/src/inputs/DateInput/index.js
@@ -45,9 +45,9 @@ class DateInput extends PureComponent {
     this.handleClose();
   };
 
-  getValidateDateValue = (date = new Date()) => {
+  getValidateDateValue = (date) => {
     let validDate = date;
-    if (typeof validDate === 'string') {
+    if (validDate !== null) {
       validDate = moment(date).toDate();
     }
 
@@ -66,12 +66,15 @@ class DateInput extends PureComponent {
           onPress={this.handleOpen}
         />
         <DateTimePicker
-          date={this.getValidateDateValue(this.props.value)}
+          date={
+            this.props.value ? moment(this.props.value).toDate() : Date.now()
+          } // Using Date.now so we have something to mock in the tests
           datePickerModeAndroid={'spinner'}
           isVisible={this.state.isVisible}
           maximumDate={
-            this.getValidateDateValue(this.props.maximumDate) ||
-            new Date(Date.now())
+            this.props.maximumDate
+              ? moment(this.props.maximumDate).toDate()
+              : Date.now()
           } // Using Date.now so we have something to mock in the tests
           mode={'date'}
           onConfirm={this.handleConfirm}

--- a/packages/apollos-ui-kit/src/inputs/DateInput/index.js
+++ b/packages/apollos-ui-kit/src/inputs/DateInput/index.js
@@ -59,11 +59,13 @@ class DateInput extends PureComponent {
           onPress={this.handleOpen}
         />
         <DateTimePicker
-          date={date || new Date()}
-          isVisible={this.state.isVisible}
+          value={date || new Date()}
           onConfirm={this.handleConfirm}
           onCancel={this.handleClose}
+          isVisible={this.state.isVisible}
           maximumDate={this.props.maximumDate || new Date(Date.now())} // Using Date.now so we have something to mock in the tests
+          datePickerModeAndroid="spinner"
+          mode="date"
         />
         {this.props.displayValue || this.props.placeholder ? (
           <FloatingLabel animation={new Animated.Value(1)}>

--- a/packages/apollos-ui-kit/src/inputs/DateInput/index.js
+++ b/packages/apollos-ui-kit/src/inputs/DateInput/index.js
@@ -69,10 +69,13 @@ class DateInput extends PureComponent {
           date={this.getValidateDateValue(this.props.value)}
           datePickerModeAndroid={'spinner'}
           isVisible={this.state.isVisible}
+          maximumDate={
+            this.getValidateDateValue(this.props.maximumDate) ||
+            new Date(Date.now())
+          } // Using Date.now so we have something to mock in the tests
           mode={'date'}
           onConfirm={this.handleConfirm}
           onCancel={this.handleClose}
-          maximumDate={this.props.maximumDate || new Date(Date.now())} // Using Date.now so we have something to mock in the tests
         />
         {this.props.displayValue || this.props.placeholder ? (
           <FloatingLabel animation={new Animated.Value(1)}>

--- a/packages/apollos-ui-onboarding/src/slides/AboutYou/__snapshots__/AboutYou.tests.js.snap
+++ b/packages/apollos-ui-onboarding/src/slides/AboutYou/__snapshots__/AboutYou.tests.js.snap
@@ -389,7 +389,7 @@ Array [
                   <DatePicker
                     date={2019-02-14T05:00:00.000Z}
                     datePickerModeAndroid="spinner"
-                    maximumDate={2019-12-02T21:05:59.360Z}
+                    maximumDate={1530518207007}
                     minuteInterval={1}
                     mode="date"
                     onCancel={[Function]}
@@ -1113,7 +1113,7 @@ exports[`The Onboarding AboutYou component should render 1`] = `
                 <DatePicker
                   date={2019-02-14T05:00:00.000Z}
                   datePickerModeAndroid="spinner"
-                  maximumDate={2019-12-02T21:05:52.941Z}
+                  maximumDate={1530518207007}
                   minuteInterval={1}
                   mode="date"
                   onCancel={[Function]}
@@ -1682,7 +1682,7 @@ exports[`The Onboarding AboutYou component should render a BackgroundComponent 1
                 <DatePicker
                   date={2019-02-14T05:00:00.000Z}
                   datePickerModeAndroid="spinner"
-                  maximumDate={2019-12-02T21:05:59.119Z}
+                  maximumDate={1530518207007}
                   minuteInterval={1}
                   mode="date"
                   onCancel={[Function]}
@@ -2207,7 +2207,7 @@ exports[`The Onboarding AboutYou component should render a custom description 1`
                 <DatePicker
                   date={2019-02-14T05:00:00.000Z}
                   datePickerModeAndroid="spinner"
-                  maximumDate={2019-12-02T21:05:58.195Z}
+                  maximumDate={1530518207007}
                   minuteInterval={1}
                   mode="date"
                   onCancel={[Function]}
@@ -2732,7 +2732,7 @@ exports[`The Onboarding AboutYou component should render a custom gender list 1`
                 <DatePicker
                   date={2019-02-14T05:00:00.000Z}
                   datePickerModeAndroid="spinner"
-                  maximumDate={2019-12-02T21:05:58.406Z}
+                  maximumDate={1530518207007}
                   minuteInterval={1}
                   mode="date"
                   onCancel={[Function]}
@@ -3257,7 +3257,7 @@ exports[`The Onboarding AboutYou component should render a custom title 1`] = `
                 <DatePicker
                   date={2019-02-14T05:00:00.000Z}
                   datePickerModeAndroid="spinner"
-                  maximumDate={2019-12-02T21:05:58.027Z}
+                  maximumDate={1530518207007}
                   minuteInterval={1}
                   mode="date"
                   onCancel={[Function]}
@@ -3794,7 +3794,7 @@ exports[`The Onboarding AboutYou component should render the selected gender 1`]
                 <DatePicker
                   date={2019-02-14T05:00:00.000Z}
                   datePickerModeAndroid="spinner"
-                  maximumDate={2019-12-02T21:05:58.575Z}
+                  maximumDate={1530518207007}
                   minuteInterval={1}
                   mode="date"
                   onCancel={[Function]}
@@ -4319,7 +4319,7 @@ exports[`The Onboarding AboutYou component should render with a selected birthda
                 <DatePicker
                   date={1989-02-14T05:00:00.000Z}
                   datePickerModeAndroid="spinner"
-                  maximumDate={2019-12-02T21:05:58.719Z}
+                  maximumDate={1530518207007}
                   minuteInterval={1}
                   mode="date"
                   onCancel={[Function]}
@@ -4866,7 +4866,7 @@ exports[`The Onboarding AboutYou component should render with errors 1`] = `
                 <DatePicker
                   date={2019-02-14T05:00:00.000Z}
                   datePickerModeAndroid="spinner"
-                  maximumDate={2019-12-02T21:05:58.905Z}
+                  maximumDate={1530518207007}
                   minuteInterval={1}
                   mode="date"
                   onCancel={[Function]}

--- a/packages/apollos-ui-onboarding/src/slides/AboutYou/__snapshots__/AboutYou.tests.js.snap
+++ b/packages/apollos-ui-onboarding/src/slides/AboutYou/__snapshots__/AboutYou.tests.js.snap
@@ -272,7 +272,10 @@ Array [
             hardwareAccelerated={false}
             hideModalContentWhileAnimating={false}
             onModalHide={[Function]}
+            onModalWillHide={[Function]}
+            onModalWillShow={[Function]}
             onRequestClose={[Function]}
+            scrollHorizontal={false}
             scrollOffset={0}
             scrollOffsetMax={0}
             scrollTo={null}
@@ -313,7 +316,10 @@ Array [
             <View
               hideModalContentWhileAnimating={false}
               onModalHide={[Function]}
+              onModalWillHide={[Function]}
+              onModalWillShow={[Function]}
               pointerEvents="box-none"
+              scrollHorizontal={false}
               scrollOffset={0}
               scrollOffsetMax={0}
               scrollTo={null}
@@ -341,10 +347,12 @@ Array [
                 style={
                   Array [
                     Object {
-                      "backgroundColor": "white",
                       "borderRadius": 13,
                       "marginBottom": 8,
                       "overflow": "hidden",
+                    },
+                    Object {
+                      "backgroundColor": "white",
                     },
                     undefined,
                   ]
@@ -380,7 +388,8 @@ Array [
                 >
                   <DatePicker
                     date={2019-02-14T05:00:00.000Z}
-                    maximumDate={2018-07-02T07:56:47.007Z}
+                    datePickerModeAndroid="spinner"
+                    maximumDate={2019-12-02T21:05:59.360Z}
                     minuteInterval={1}
                     mode="date"
                     onCancel={[Function]}
@@ -440,13 +449,18 @@ Array [
                 onResponderTerminationRequest={[Function]}
                 onStartShouldSetResponder={[Function]}
                 style={
-                  Object {
-                    "backgroundColor": "white",
-                    "borderRadius": 13,
-                    "height": 57,
-                    "justifyContent": "center",
-                    "marginBottom": 0,
-                  }
+                  Array [
+                    Object {
+                      "borderRadius": 13,
+                      "height": 57,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                    },
+                    Object {
+                      "backgroundColor": "white",
+                    },
+                    undefined,
+                  ]
                 }
               >
                 <Text
@@ -982,7 +996,10 @@ exports[`The Onboarding AboutYou component should render 1`] = `
           hardwareAccelerated={false}
           hideModalContentWhileAnimating={false}
           onModalHide={[Function]}
+          onModalWillHide={[Function]}
+          onModalWillShow={[Function]}
           onRequestClose={[Function]}
+          scrollHorizontal={false}
           scrollOffset={0}
           scrollOffsetMax={0}
           scrollTo={null}
@@ -1023,7 +1040,10 @@ exports[`The Onboarding AboutYou component should render 1`] = `
           <View
             hideModalContentWhileAnimating={false}
             onModalHide={[Function]}
+            onModalWillHide={[Function]}
+            onModalWillShow={[Function]}
             pointerEvents="box-none"
+            scrollHorizontal={false}
             scrollOffset={0}
             scrollOffsetMax={0}
             scrollTo={null}
@@ -1051,10 +1071,12 @@ exports[`The Onboarding AboutYou component should render 1`] = `
               style={
                 Array [
                   Object {
-                    "backgroundColor": "white",
                     "borderRadius": 13,
                     "marginBottom": 8,
                     "overflow": "hidden",
+                  },
+                  Object {
+                    "backgroundColor": "white",
                   },
                   undefined,
                 ]
@@ -1090,7 +1112,8 @@ exports[`The Onboarding AboutYou component should render 1`] = `
               >
                 <DatePicker
                   date={2019-02-14T05:00:00.000Z}
-                  maximumDate={2018-07-02T07:56:47.007Z}
+                  datePickerModeAndroid="spinner"
+                  maximumDate={2019-12-02T21:05:52.941Z}
                   minuteInterval={1}
                   mode="date"
                   onCancel={[Function]}
@@ -1150,13 +1173,18 @@ exports[`The Onboarding AboutYou component should render 1`] = `
               onResponderTerminationRequest={[Function]}
               onStartShouldSetResponder={[Function]}
               style={
-                Object {
-                  "backgroundColor": "white",
-                  "borderRadius": 13,
-                  "height": 57,
-                  "justifyContent": "center",
-                  "marginBottom": 0,
-                }
+                Array [
+                  Object {
+                    "borderRadius": 13,
+                    "height": 57,
+                    "justifyContent": "center",
+                    "marginBottom": 0,
+                  },
+                  Object {
+                    "backgroundColor": "white",
+                  },
+                  undefined,
+                ]
               }
             >
               <Text
@@ -1537,7 +1565,10 @@ exports[`The Onboarding AboutYou component should render a BackgroundComponent 1
           hardwareAccelerated={false}
           hideModalContentWhileAnimating={false}
           onModalHide={[Function]}
+          onModalWillHide={[Function]}
+          onModalWillShow={[Function]}
           onRequestClose={[Function]}
+          scrollHorizontal={false}
           scrollOffset={0}
           scrollOffsetMax={0}
           scrollTo={null}
@@ -1578,7 +1609,10 @@ exports[`The Onboarding AboutYou component should render a BackgroundComponent 1
           <View
             hideModalContentWhileAnimating={false}
             onModalHide={[Function]}
+            onModalWillHide={[Function]}
+            onModalWillShow={[Function]}
             pointerEvents="box-none"
+            scrollHorizontal={false}
             scrollOffset={0}
             scrollOffsetMax={0}
             scrollTo={null}
@@ -1606,10 +1640,12 @@ exports[`The Onboarding AboutYou component should render a BackgroundComponent 1
               style={
                 Array [
                   Object {
-                    "backgroundColor": "white",
                     "borderRadius": 13,
                     "marginBottom": 8,
                     "overflow": "hidden",
+                  },
+                  Object {
+                    "backgroundColor": "white",
                   },
                   undefined,
                 ]
@@ -1645,7 +1681,8 @@ exports[`The Onboarding AboutYou component should render a BackgroundComponent 1
               >
                 <DatePicker
                   date={2019-02-14T05:00:00.000Z}
-                  maximumDate={2018-07-02T07:56:47.007Z}
+                  datePickerModeAndroid="spinner"
+                  maximumDate={2019-12-02T21:05:59.119Z}
                   minuteInterval={1}
                   mode="date"
                   onCancel={[Function]}
@@ -1705,13 +1742,18 @@ exports[`The Onboarding AboutYou component should render a BackgroundComponent 1
               onResponderTerminationRequest={[Function]}
               onStartShouldSetResponder={[Function]}
               style={
-                Object {
-                  "backgroundColor": "white",
-                  "borderRadius": 13,
-                  "height": 57,
-                  "justifyContent": "center",
-                  "marginBottom": 0,
-                }
+                Array [
+                  Object {
+                    "borderRadius": 13,
+                    "height": 57,
+                    "justifyContent": "center",
+                    "marginBottom": 0,
+                  },
+                  Object {
+                    "backgroundColor": "white",
+                  },
+                  undefined,
+                ]
               }
             >
               <Text
@@ -2048,7 +2090,10 @@ exports[`The Onboarding AboutYou component should render a custom description 1`
           hardwareAccelerated={false}
           hideModalContentWhileAnimating={false}
           onModalHide={[Function]}
+          onModalWillHide={[Function]}
+          onModalWillShow={[Function]}
           onRequestClose={[Function]}
+          scrollHorizontal={false}
           scrollOffset={0}
           scrollOffsetMax={0}
           scrollTo={null}
@@ -2089,7 +2134,10 @@ exports[`The Onboarding AboutYou component should render a custom description 1`
           <View
             hideModalContentWhileAnimating={false}
             onModalHide={[Function]}
+            onModalWillHide={[Function]}
+            onModalWillShow={[Function]}
             pointerEvents="box-none"
+            scrollHorizontal={false}
             scrollOffset={0}
             scrollOffsetMax={0}
             scrollTo={null}
@@ -2117,10 +2165,12 @@ exports[`The Onboarding AboutYou component should render a custom description 1`
               style={
                 Array [
                   Object {
-                    "backgroundColor": "white",
                     "borderRadius": 13,
                     "marginBottom": 8,
                     "overflow": "hidden",
+                  },
+                  Object {
+                    "backgroundColor": "white",
                   },
                   undefined,
                 ]
@@ -2156,7 +2206,8 @@ exports[`The Onboarding AboutYou component should render a custom description 1`
               >
                 <DatePicker
                   date={2019-02-14T05:00:00.000Z}
-                  maximumDate={2018-07-02T07:56:47.007Z}
+                  datePickerModeAndroid="spinner"
+                  maximumDate={2019-12-02T21:05:58.195Z}
                   minuteInterval={1}
                   mode="date"
                   onCancel={[Function]}
@@ -2216,13 +2267,18 @@ exports[`The Onboarding AboutYou component should render a custom description 1`
               onResponderTerminationRequest={[Function]}
               onStartShouldSetResponder={[Function]}
               style={
-                Object {
-                  "backgroundColor": "white",
-                  "borderRadius": 13,
-                  "height": 57,
-                  "justifyContent": "center",
-                  "marginBottom": 0,
-                }
+                Array [
+                  Object {
+                    "borderRadius": 13,
+                    "height": 57,
+                    "justifyContent": "center",
+                    "marginBottom": 0,
+                  },
+                  Object {
+                    "backgroundColor": "white",
+                  },
+                  undefined,
+                ]
               }
             >
               <Text
@@ -2559,7 +2615,10 @@ exports[`The Onboarding AboutYou component should render a custom gender list 1`
           hardwareAccelerated={false}
           hideModalContentWhileAnimating={false}
           onModalHide={[Function]}
+          onModalWillHide={[Function]}
+          onModalWillShow={[Function]}
           onRequestClose={[Function]}
+          scrollHorizontal={false}
           scrollOffset={0}
           scrollOffsetMax={0}
           scrollTo={null}
@@ -2600,7 +2659,10 @@ exports[`The Onboarding AboutYou component should render a custom gender list 1`
           <View
             hideModalContentWhileAnimating={false}
             onModalHide={[Function]}
+            onModalWillHide={[Function]}
+            onModalWillShow={[Function]}
             pointerEvents="box-none"
+            scrollHorizontal={false}
             scrollOffset={0}
             scrollOffsetMax={0}
             scrollTo={null}
@@ -2628,10 +2690,12 @@ exports[`The Onboarding AboutYou component should render a custom gender list 1`
               style={
                 Array [
                   Object {
-                    "backgroundColor": "white",
                     "borderRadius": 13,
                     "marginBottom": 8,
                     "overflow": "hidden",
+                  },
+                  Object {
+                    "backgroundColor": "white",
                   },
                   undefined,
                 ]
@@ -2667,7 +2731,8 @@ exports[`The Onboarding AboutYou component should render a custom gender list 1`
               >
                 <DatePicker
                   date={2019-02-14T05:00:00.000Z}
-                  maximumDate={2018-07-02T07:56:47.007Z}
+                  datePickerModeAndroid="spinner"
+                  maximumDate={2019-12-02T21:05:58.406Z}
                   minuteInterval={1}
                   mode="date"
                   onCancel={[Function]}
@@ -2727,13 +2792,18 @@ exports[`The Onboarding AboutYou component should render a custom gender list 1`
               onResponderTerminationRequest={[Function]}
               onStartShouldSetResponder={[Function]}
               style={
-                Object {
-                  "backgroundColor": "white",
-                  "borderRadius": 13,
-                  "height": 57,
-                  "justifyContent": "center",
-                  "marginBottom": 0,
-                }
+                Array [
+                  Object {
+                    "borderRadius": 13,
+                    "height": 57,
+                    "justifyContent": "center",
+                    "marginBottom": 0,
+                  },
+                  Object {
+                    "backgroundColor": "white",
+                  },
+                  undefined,
+                ]
               }
             >
               <Text
@@ -3070,7 +3140,10 @@ exports[`The Onboarding AboutYou component should render a custom title 1`] = `
           hardwareAccelerated={false}
           hideModalContentWhileAnimating={false}
           onModalHide={[Function]}
+          onModalWillHide={[Function]}
+          onModalWillShow={[Function]}
           onRequestClose={[Function]}
+          scrollHorizontal={false}
           scrollOffset={0}
           scrollOffsetMax={0}
           scrollTo={null}
@@ -3111,7 +3184,10 @@ exports[`The Onboarding AboutYou component should render a custom title 1`] = `
           <View
             hideModalContentWhileAnimating={false}
             onModalHide={[Function]}
+            onModalWillHide={[Function]}
+            onModalWillShow={[Function]}
             pointerEvents="box-none"
+            scrollHorizontal={false}
             scrollOffset={0}
             scrollOffsetMax={0}
             scrollTo={null}
@@ -3139,10 +3215,12 @@ exports[`The Onboarding AboutYou component should render a custom title 1`] = `
               style={
                 Array [
                   Object {
-                    "backgroundColor": "white",
                     "borderRadius": 13,
                     "marginBottom": 8,
                     "overflow": "hidden",
+                  },
+                  Object {
+                    "backgroundColor": "white",
                   },
                   undefined,
                 ]
@@ -3178,7 +3256,8 @@ exports[`The Onboarding AboutYou component should render a custom title 1`] = `
               >
                 <DatePicker
                   date={2019-02-14T05:00:00.000Z}
-                  maximumDate={2018-07-02T07:56:47.007Z}
+                  datePickerModeAndroid="spinner"
+                  maximumDate={2019-12-02T21:05:58.027Z}
                   minuteInterval={1}
                   mode="date"
                   onCancel={[Function]}
@@ -3238,13 +3317,18 @@ exports[`The Onboarding AboutYou component should render a custom title 1`] = `
               onResponderTerminationRequest={[Function]}
               onStartShouldSetResponder={[Function]}
               style={
-                Object {
-                  "backgroundColor": "white",
-                  "borderRadius": 13,
-                  "height": 57,
-                  "justifyContent": "center",
-                  "marginBottom": 0,
-                }
+                Array [
+                  Object {
+                    "borderRadius": 13,
+                    "height": 57,
+                    "justifyContent": "center",
+                    "marginBottom": 0,
+                  },
+                  Object {
+                    "backgroundColor": "white",
+                  },
+                  undefined,
+                ]
               }
             >
               <Text
@@ -3593,7 +3677,10 @@ exports[`The Onboarding AboutYou component should render the selected gender 1`]
           hardwareAccelerated={false}
           hideModalContentWhileAnimating={false}
           onModalHide={[Function]}
+          onModalWillHide={[Function]}
+          onModalWillShow={[Function]}
           onRequestClose={[Function]}
+          scrollHorizontal={false}
           scrollOffset={0}
           scrollOffsetMax={0}
           scrollTo={null}
@@ -3634,7 +3721,10 @@ exports[`The Onboarding AboutYou component should render the selected gender 1`]
           <View
             hideModalContentWhileAnimating={false}
             onModalHide={[Function]}
+            onModalWillHide={[Function]}
+            onModalWillShow={[Function]}
             pointerEvents="box-none"
+            scrollHorizontal={false}
             scrollOffset={0}
             scrollOffsetMax={0}
             scrollTo={null}
@@ -3662,10 +3752,12 @@ exports[`The Onboarding AboutYou component should render the selected gender 1`]
               style={
                 Array [
                   Object {
-                    "backgroundColor": "white",
                     "borderRadius": 13,
                     "marginBottom": 8,
                     "overflow": "hidden",
+                  },
+                  Object {
+                    "backgroundColor": "white",
                   },
                   undefined,
                 ]
@@ -3701,7 +3793,8 @@ exports[`The Onboarding AboutYou component should render the selected gender 1`]
               >
                 <DatePicker
                   date={2019-02-14T05:00:00.000Z}
-                  maximumDate={2018-07-02T07:56:47.007Z}
+                  datePickerModeAndroid="spinner"
+                  maximumDate={2019-12-02T21:05:58.575Z}
                   minuteInterval={1}
                   mode="date"
                   onCancel={[Function]}
@@ -3761,13 +3854,18 @@ exports[`The Onboarding AboutYou component should render the selected gender 1`]
               onResponderTerminationRequest={[Function]}
               onStartShouldSetResponder={[Function]}
               style={
-                Object {
-                  "backgroundColor": "white",
-                  "borderRadius": 13,
-                  "height": 57,
-                  "justifyContent": "center",
-                  "marginBottom": 0,
-                }
+                Array [
+                  Object {
+                    "borderRadius": 13,
+                    "height": 57,
+                    "justifyContent": "center",
+                    "marginBottom": 0,
+                  },
+                  Object {
+                    "backgroundColor": "white",
+                  },
+                  undefined,
+                ]
               }
             >
               <Text
@@ -4104,7 +4202,10 @@ exports[`The Onboarding AboutYou component should render with a selected birthda
           hardwareAccelerated={false}
           hideModalContentWhileAnimating={false}
           onModalHide={[Function]}
+          onModalWillHide={[Function]}
+          onModalWillShow={[Function]}
           onRequestClose={[Function]}
+          scrollHorizontal={false}
           scrollOffset={0}
           scrollOffsetMax={0}
           scrollTo={null}
@@ -4145,7 +4246,10 @@ exports[`The Onboarding AboutYou component should render with a selected birthda
           <View
             hideModalContentWhileAnimating={false}
             onModalHide={[Function]}
+            onModalWillHide={[Function]}
+            onModalWillShow={[Function]}
             pointerEvents="box-none"
+            scrollHorizontal={false}
             scrollOffset={0}
             scrollOffsetMax={0}
             scrollTo={null}
@@ -4173,10 +4277,12 @@ exports[`The Onboarding AboutYou component should render with a selected birthda
               style={
                 Array [
                   Object {
-                    "backgroundColor": "white",
                     "borderRadius": 13,
                     "marginBottom": 8,
                     "overflow": "hidden",
+                  },
+                  Object {
+                    "backgroundColor": "white",
                   },
                   undefined,
                 ]
@@ -4212,7 +4318,8 @@ exports[`The Onboarding AboutYou component should render with a selected birthda
               >
                 <DatePicker
                   date={1989-02-14T05:00:00.000Z}
-                  maximumDate={2018-07-02T07:56:47.007Z}
+                  datePickerModeAndroid="spinner"
+                  maximumDate={2019-12-02T21:05:58.719Z}
                   minuteInterval={1}
                   mode="date"
                   onCancel={[Function]}
@@ -4272,13 +4379,18 @@ exports[`The Onboarding AboutYou component should render with a selected birthda
               onResponderTerminationRequest={[Function]}
               onStartShouldSetResponder={[Function]}
               style={
-                Object {
-                  "backgroundColor": "white",
-                  "borderRadius": 13,
-                  "height": 57,
-                  "justifyContent": "center",
-                  "marginBottom": 0,
-                }
+                Array [
+                  Object {
+                    "borderRadius": 13,
+                    "height": 57,
+                    "justifyContent": "center",
+                    "marginBottom": 0,
+                  },
+                  Object {
+                    "backgroundColor": "white",
+                  },
+                  undefined,
+                ]
               }
             >
               <Text
@@ -4637,7 +4749,10 @@ exports[`The Onboarding AboutYou component should render with errors 1`] = `
           hardwareAccelerated={false}
           hideModalContentWhileAnimating={false}
           onModalHide={[Function]}
+          onModalWillHide={[Function]}
+          onModalWillShow={[Function]}
           onRequestClose={[Function]}
+          scrollHorizontal={false}
           scrollOffset={0}
           scrollOffsetMax={0}
           scrollTo={null}
@@ -4678,7 +4793,10 @@ exports[`The Onboarding AboutYou component should render with errors 1`] = `
           <View
             hideModalContentWhileAnimating={false}
             onModalHide={[Function]}
+            onModalWillHide={[Function]}
+            onModalWillShow={[Function]}
             pointerEvents="box-none"
+            scrollHorizontal={false}
             scrollOffset={0}
             scrollOffsetMax={0}
             scrollTo={null}
@@ -4706,10 +4824,12 @@ exports[`The Onboarding AboutYou component should render with errors 1`] = `
               style={
                 Array [
                   Object {
-                    "backgroundColor": "white",
                     "borderRadius": 13,
                     "marginBottom": 8,
                     "overflow": "hidden",
+                  },
+                  Object {
+                    "backgroundColor": "white",
                   },
                   undefined,
                 ]
@@ -4745,7 +4865,8 @@ exports[`The Onboarding AboutYou component should render with errors 1`] = `
               >
                 <DatePicker
                   date={2019-02-14T05:00:00.000Z}
-                  maximumDate={2018-07-02T07:56:47.007Z}
+                  datePickerModeAndroid="spinner"
+                  maximumDate={2019-12-02T21:05:58.905Z}
                   minuteInterval={1}
                   mode="date"
                   onCancel={[Function]}
@@ -4805,13 +4926,18 @@ exports[`The Onboarding AboutYou component should render with errors 1`] = `
               onResponderTerminationRequest={[Function]}
               onStartShouldSetResponder={[Function]}
               style={
-                Object {
-                  "backgroundColor": "white",
-                  "borderRadius": 13,
-                  "height": 57,
-                  "justifyContent": "center",
-                  "marginBottom": 0,
-                }
+                Array [
+                  Object {
+                    "borderRadius": 13,
+                    "height": 57,
+                    "justifyContent": "center",
+                    "marginBottom": 0,
+                  },
+                  Object {
+                    "backgroundColor": "white",
+                  },
+                  undefined,
+                ]
               }
             >
               <Text

--- a/packages/apollos-ui-onboarding/src/slides/AboutYou/__snapshots__/AboutYouConnected.tests.js.snap
+++ b/packages/apollos-ui-onboarding/src/slides/AboutYou/__snapshots__/AboutYouConnected.tests.js.snap
@@ -286,7 +286,10 @@ Array [
             hardwareAccelerated={false}
             hideModalContentWhileAnimating={false}
             onModalHide={[Function]}
+            onModalWillHide={[Function]}
+            onModalWillShow={[Function]}
             onRequestClose={[Function]}
+            scrollHorizontal={false}
             scrollOffset={0}
             scrollOffsetMax={0}
             scrollTo={null}
@@ -327,7 +330,10 @@ Array [
             <View
               hideModalContentWhileAnimating={false}
               onModalHide={[Function]}
+              onModalWillHide={[Function]}
+              onModalWillShow={[Function]}
               pointerEvents="box-none"
+              scrollHorizontal={false}
               scrollOffset={0}
               scrollOffsetMax={0}
               scrollTo={null}
@@ -355,10 +361,12 @@ Array [
                 style={
                   Array [
                     Object {
-                      "backgroundColor": "white",
                       "borderRadius": 13,
                       "marginBottom": 8,
                       "overflow": "hidden",
+                    },
+                    Object {
+                      "backgroundColor": "white",
                     },
                     undefined,
                   ]
@@ -394,7 +402,8 @@ Array [
                 >
                   <DatePicker
                     date={1980-02-10T05:00:00.000Z}
-                    maximumDate={2018-07-02T07:56:47.007Z}
+                    datePickerModeAndroid="spinner"
+                    maximumDate={2019-12-02T21:05:58.616Z}
                     minuteInterval={1}
                     mode="date"
                     onCancel={[Function]}
@@ -454,13 +463,18 @@ Array [
                 onResponderTerminationRequest={[Function]}
                 onStartShouldSetResponder={[Function]}
                 style={
-                  Object {
-                    "backgroundColor": "white",
-                    "borderRadius": 13,
-                    "height": 57,
-                    "justifyContent": "center",
-                    "marginBottom": 0,
-                  }
+                  Array [
+                    Object {
+                      "borderRadius": 13,
+                      "height": 57,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                    },
+                    Object {
+                      "backgroundColor": "white",
+                    },
+                    undefined,
+                  ]
                 }
               >
                 <Text
@@ -997,7 +1011,10 @@ Array [
             hardwareAccelerated={false}
             hideModalContentWhileAnimating={false}
             onModalHide={[Function]}
+            onModalWillHide={[Function]}
+            onModalWillShow={[Function]}
             onRequestClose={[Function]}
+            scrollHorizontal={false}
             scrollOffset={0}
             scrollOffsetMax={0}
             scrollTo={null}
@@ -1038,7 +1055,10 @@ Array [
             <View
               hideModalContentWhileAnimating={false}
               onModalHide={[Function]}
+              onModalWillHide={[Function]}
+              onModalWillShow={[Function]}
               pointerEvents="box-none"
+              scrollHorizontal={false}
               scrollOffset={0}
               scrollOffsetMax={0}
               scrollTo={null}
@@ -1066,10 +1086,12 @@ Array [
                 style={
                   Array [
                     Object {
-                      "backgroundColor": "white",
                       "borderRadius": 13,
                       "marginBottom": 8,
                       "overflow": "hidden",
+                    },
+                    Object {
+                      "backgroundColor": "white",
                     },
                     undefined,
                   ]
@@ -1105,7 +1127,8 @@ Array [
                 >
                   <DatePicker
                     date={2019-02-14T05:00:00.000Z}
-                    maximumDate={2018-07-02T07:56:47.007Z}
+                    datePickerModeAndroid="spinner"
+                    maximumDate={2019-12-02T21:05:50.934Z}
                     minuteInterval={1}
                     mode="date"
                     onCancel={[Function]}
@@ -1165,13 +1188,18 @@ Array [
                 onResponderTerminationRequest={[Function]}
                 onStartShouldSetResponder={[Function]}
                 style={
-                  Object {
-                    "backgroundColor": "white",
-                    "borderRadius": 13,
-                    "height": 57,
-                    "justifyContent": "center",
-                    "marginBottom": 0,
-                  }
+                  Array [
+                    Object {
+                      "borderRadius": 13,
+                      "height": 57,
+                      "justifyContent": "center",
+                      "marginBottom": 0,
+                    },
+                    Object {
+                      "backgroundColor": "white",
+                    },
+                    undefined,
+                  ]
                 }
               >
                 <Text

--- a/packages/apollos-ui-onboarding/src/slides/AboutYou/__snapshots__/AboutYouConnected.tests.js.snap
+++ b/packages/apollos-ui-onboarding/src/slides/AboutYou/__snapshots__/AboutYouConnected.tests.js.snap
@@ -403,7 +403,7 @@ Array [
                   <DatePicker
                     date={1980-02-10T05:00:00.000Z}
                     datePickerModeAndroid="spinner"
-                    maximumDate={2019-12-02T21:05:58.616Z}
+                    maximumDate={1530518207007}
                     minuteInterval={1}
                     mode="date"
                     onCancel={[Function]}
@@ -1128,7 +1128,7 @@ Array [
                   <DatePicker
                     date={2019-02-14T05:00:00.000Z}
                     datePickerModeAndroid="spinner"
-                    maximumDate={2019-12-02T21:05:50.934Z}
+                    maximumDate={1530518207007}
                     minuteInterval={1}
                     mode="date"
                     onCancel={[Function]}

--- a/packages/apolloschurchapp/metro.config.js
+++ b/packages/apolloschurchapp/metro.config.js
@@ -33,6 +33,7 @@ const sharedNativeModules = [
   'react-native-gesture-handler',
   'react-native-video',
   'react-native-video-controls',
+  'react-native-modal-datetime-picker',
   '@apollosproject/react-native-airplay-btn',
   'react-navigation',
 ];

--- a/packages/apolloschurchapp/package.json
+++ b/packages/apolloschurchapp/package.json
@@ -116,6 +116,7 @@
     "react-native-video": "^5.0.0",
     "react-native-video-controls": "2.2.3",
     "react-native-webview": "^5.2.0",
+    "react-native-modal-datetime-picker": "7.6.0",
     "react-navigation": "^3.11.0",
     "recompose": "^0.30.0",
     "rn-fetch-blob": "^0.10.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13525,12 +13525,12 @@ react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-native-animatable@^1.2.4:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/react-native-animatable/-/react-native-animatable-1.3.2.tgz#4783ee1a73dc98815aef234ce6b819f80bfe7d80"
-  integrity sha512-rmah3KQ63ft8DxkzFUwJSuZeq+oSYwldoGF4DTOR5WM2WR5wiWLgBAtrAHlI3Di3by323uOR21s+MlqPcHz2Kw==
+react-native-animatable@1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/react-native-animatable/-/react-native-animatable-1.3.3.tgz#a13a4af8258e3bb14d0a9d839917e9bb9274ec8a"
+  integrity sha512-2ckIxZQAsvWn25Ho+DK3d1mXIgj7tITkrS4pYDvx96WyOttSvzzFeQnM2od0+FUMzILbdHDsDEqZvnz1DYNQ1w==
   dependencies:
-    prop-types "^15.5.10"
+    prop-types "^15.7.2"
 
 react-native-config@^0.11.7:
   version "0.11.7"
@@ -13586,21 +13586,21 @@ react-native-maps@0.25.0:
   resolved "https://registry.yarnpkg.com/react-native-maps/-/react-native-maps-0.25.0.tgz#81bc51eb50e33811a9e1c345cc48869413ead67d"
   integrity sha512-PFJuW1pt+HnnnN0m0OGk29RSvICFVkK/DScX6cUk0SuCSN2DAHx0y6y57lZyYXcYqU4J4usNpfxgp/ccjASDiw==
 
-react-native-modal-datetime-picker@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/react-native-modal-datetime-picker/-/react-native-modal-datetime-picker-6.0.0.tgz#8018994524122ad48fd6bc66f26f623c75a49fb3"
-  integrity sha512-O8brvSXgvRtfHzAyCNSrPcylE05cyK30D8/7rM0kjXLnlDcoiXtEl62qDQw8wnJOAL6kQFGn/iQ8H4mGXptiHw==
+react-native-modal-datetime-picker@7.6.0:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/react-native-modal-datetime-picker/-/react-native-modal-datetime-picker-7.6.0.tgz#6818f221010d0f61a6396a956b303fee65726fee"
+  integrity sha512-p7MquU/oAFO+S7+d1IYYK/8b9mroZXuStK2HA2FxX3e8O1YeNyq2Bggr4KPr6D0saJ/6iGzq8pFwN0YfaCW9+A==
   dependencies:
-    prop-types "^15.6.1"
-    react-native-modal "^6.2.0"
+    prop-types "^15.7.2"
+    react-native-modal "^11.0.2"
 
-react-native-modal@^6.2.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/react-native-modal/-/react-native-modal-6.5.0.tgz#46220b2289a41597d344c1db17454611b426a758"
-  integrity sha512-ewchdETAGd32xLGLK93NETEGkRcePtN7ZwjmLSQnNW1Zd0SRUYE8NqftjamPyfKvK0i2DZjX4YAghGZTqaRUbA==
+react-native-modal@^11.0.2:
+  version "11.5.3"
+  resolved "https://registry.yarnpkg.com/react-native-modal/-/react-native-modal-11.5.3.tgz#28b4c761680a165eaf1d2c0fb08e272c0191b39f"
+  integrity sha512-U6RghSkZUZ6c0LHMbwAnVscEwGoI58eXfBstVs18t50miV0GmLcJhIOu5OND+SDGVkBQFiGFRu/pTUJaA7wfGw==
   dependencies:
-    prop-types "^15.6.1"
-    react-native-animatable "^1.2.4"
+    prop-types "^15.6.2"
+    react-native-animatable "1.3.3"
 
 react-native-music-control@0.10.5:
   version "0.10.5"


### PR DESCRIPTION
## DESCRIPTION

Users on willow were confused by the calendar modal on Android. The default modal doesn't make it clear that you can tap "2019" to jump straight to the year picker. This changes the style of the modal on android so that the options you have to change the date are more clear.

<img width="584" alt="Screen Shot 2019-12-02 at 1 22 31 PM" src="https://user-images.githubusercontent.com/1637694/69984702-b131b280-1507-11ea-809b-30378b82620b.png">
<img width="830" alt="Screen Shot 2019-12-02 at 1 14 46 PM" src="https://user-images.githubusercontent.com/1637694/69984703-b262df80-1507-11ea-9673-41d4f9b9ca81.png">


### What does this PR do, or why is it needed?

### What design trade-offs/decisions were made?

### How do I test this PR?

### What automated tests did you write?

n/a

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
