### PR TITLE
Trim Profile Fields

### DIFF
--- a/packages/apollos-data-connector-rock/src/people/__tests__/data-source.tests.js
+++ b/packages/apollos-data-connector-rock/src/people/__tests__/data-source.tests.js
@@ -123,7 +123,7 @@ describe('Person', () => {
     dataSource.patch = buildGetMock({}, dataSource);
     const result = dataSource.updateProfile([
       {
-        field: 'FirstName',
+        field: '        FirstName',
         value: 'Nick',
       },
     ]);

--- a/packages/apollos-data-connector-rock/src/people/data-source.js
+++ b/packages/apollos-data-connector-rock/src/people/data-source.js
@@ -71,7 +71,7 @@ export default class Person extends RockApolloDataSource {
     const fieldsAsObject = fields.reduce(
       (accum, { field, value }) => ({
         ...accum,
-        [field]: value,
+        [field]: typeof value === 'string' ? value.trim() : value,
       }),
       {}
     );


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Trims any string fields related to user profile to ensure we don't get extra spaces. This is primarily in place to prevent users from entering unwanted spaces into their name.

### What design trade-offs/decisions were made?

Did this on the server so that we don't have to worry about changing it everywhere on the client.

### How do I test this PR?

1. In onboarding change your name to have several spaces in front
2. On the next screen,  you should see that it's been trimmed

### What automated tests did you write?

## SCREENSHOTS

![Screen Recording 2019-12-02 at 05 10 PM](https://user-images.githubusercontent.com/29125070/69999482-c23dec00-1526-11ea-90c0-defb4a9c455f.gif)

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
