### PR TITLE
Removes auth prefetch cache attempt

### DIFF
--- a/packages/apollos-data-connector-rock/src/auth/data-source.js
+++ b/packages/apollos-data-connector-rock/src/auth/data-source.js
@@ -13,16 +13,6 @@ export default class AuthDataSource extends RockApolloDataSource {
 
   userToken = null;
 
-  initialize(config) {
-    super.initialize(config);
-    if (config.context.rockCookie) {
-      // fetches the current person
-      // this method will try to cache the current person on the context
-      // removing the need to fetch each and every time
-      this.getCurrentPerson();
-    }
-  }
-
   getCurrentPerson = async ({ cookie = null } = { cookie: null }) => {
     const { rockCookie, currentPerson } = this.context;
     const userCookie = cookie || rockCookie;


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Gage and I experimented with this code to try and pre-cache the current user as early as possible. The hope was that this would help (caching the user early enough to avoid more than one current user request) in more requests than it hurt (fetching the current user needlessly). This has proven to not be the case, however. Spot checking of the data shows that because the `initialize` method can't be called with the async keyword, the extra currentUser fetch never populates the cache in time.

### What design trade-offs/decisions were made?

### How do I test this PR?

1. Open the app
2. Login
3. Browse around
4. Nothing should seem different

### What automated tests did you write?

n/a

## TODO:
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [x] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
