### PR TITLE
Adds support for the auth register endpoints to properly accept Gender/Birthdate

### DIFF
--- a/packages/apollos-church-api/local.graphql
+++ b/packages/apollos-church-api/local.graphql
@@ -1,3 +1,5 @@
+directive @cacheControl(maxAge: Int, scope: CacheControlScope) on FIELD_DEFINITION | OBJECT | INTERFACE
+
 enum ACTION_FEATURE_ACTION {
   READ_CONTENT
   READ_EVENT

--- a/packages/apollos-data-connector-rock/src/auth-sms/__tests__/__snapshots__/index.js.snap
+++ b/packages/apollos-data-connector-rock/src/auth-sms/__tests__/__snapshots__/index.js.snap
@@ -367,6 +367,82 @@ Array [
 ]
 `;
 
+exports[`AuthSms schema registers a new user via their phone number, pin, and gender 1`] = `
+Object {
+  "data": Object {
+    "registerWithSms": Object {
+      "token": "foo",
+    },
+  },
+}
+`;
+
+exports[`AuthSms schema registers a new user via their phone number, pin, and gender: create new phone number 1`] = `
+Array [
+  Array [
+    "/PhoneNumbers",
+    Object {
+      "CountryCode": 1,
+      "IsMessagingEnabled": true,
+      "IsSystem": false,
+      "Number": "5133061126",
+      "NumberTypeValueId": 12,
+      "PersonId": 123,
+    },
+  ],
+]
+`;
+
+exports[`AuthSms schema registers a new user via their phone number, pin, and gender: create user profile 1`] = `
+Array [
+  Array [
+    Object {
+      "FirstName": "Burke",
+      "Gender": 1,
+      "LastName": "Shartsis",
+      "email": null,
+    },
+  ],
+]
+`;
+
+exports[`AuthSms schema registers a new user via their phone number, pin, and gender: login user 1`] = `
+Array [
+  Array [
+    Object {
+      "identity": "5133061126",
+      "password": "5dd39e500e9806efbb8c0e92d61d78e5fd20efcd2788d0ef2c56ad5df3cd2649",
+    },
+  ],
+]
+`;
+
+exports[`AuthSms schema registers a new user via their phone number, pin, and gender: try and find phone number / find user login 1`] = `
+Array [
+  Array [
+    "/UserLogins?loadAttributes=expanded&%24filter=UserName%20eq%20%275133061126%27&%24top=1",
+    Object {},
+    Object {},
+  ],
+  Array [
+    "/PhoneNumbers?loadAttributes=expanded&%24filter=Number%20eq%20%275133061126%27",
+    Object {},
+    Object {},
+  ],
+]
+`;
+
+exports[`AuthSms schema registers a new user via their phone number, pin, and gender: update person id on login 1`] = `
+Array [
+  Array [
+    "/UserLogins/123",
+    Object {
+      "PersonId": 123,
+    },
+  ],
+]
+`;
+
 exports[`AuthSms schema requests an SMS pin with an existing user login 1`] = `
 Object {
   "data": Object {

--- a/packages/apollos-data-connector-rock/src/auth-sms/__tests__/index.js
+++ b/packages/apollos-data-connector-rock/src/auth-sms/__tests__/index.js
@@ -6,6 +6,7 @@ import { peopleSchema } from '@apollosproject/data-schema';
 
 import * as AuthSms from '../index';
 import * as Auth from '../../auth/index';
+import * as Person from '../../people/index';
 
 ApollosConfig.loadJs({
   ROCK: {
@@ -29,7 +30,12 @@ const Sms = {
   dataSource: SmsDataSource,
 };
 
-const { getContext, getSchema } = createTestHelpers({ Auth, AuthSms, Sms });
+const { getContext, getSchema } = createTestHelpers({
+  Auth,
+  AuthSms,
+  Sms,
+  Person,
+});
 
 describe('AuthSms schema', () => {
   let schema;
@@ -398,6 +404,56 @@ describe('AuthSms schema', () => {
     const query = `
       mutation {
         registerWithSms(phoneNumber: "5133061126", pin: "123456", userProfile: [{ field: FirstName, value: "Burke" }, { field: LastName, value: "Shartsis" }]) {
+          token
+        }
+      }
+    `;
+    const rootValue = {};
+
+    const getMock = jest.fn((path) => {
+      if (path.includes('/PhoneNumbers')) {
+        return Promise.resolve([]);
+      }
+      return Promise.resolve([{ id: 123 }]);
+    });
+    const patchMock = jest.fn();
+    const authenticateMock = jest.fn(() =>
+      Promise.resolve({ token: 'foo', rockCookie: 'bar' })
+    );
+    const postMock = jest.fn();
+    const createUserProfileMock = jest.fn(() => Promise.resolve(123));
+
+    context.dataSources.AuthSms.get = getMock;
+    context.dataSources.AuthSms.patch = patchMock;
+    context.dataSources.AuthSms.post = postMock;
+    context.dataSources.Auth.authenticate = authenticateMock;
+    context.dataSources.Auth.createUserProfile = createUserProfileMock;
+
+    const result = await graphql(schema, query, rootValue, context);
+    expect(result).toMatchSnapshot();
+    expect(getMock.mock.calls).toMatchSnapshot(
+      'try and find phone number / find user login'
+    );
+    expect(patchMock.mock.calls).toMatchSnapshot('update person id on login');
+    expect(authenticateMock.mock.calls).toMatchSnapshot('login user');
+    expect(postMock.mock.calls).toMatchSnapshot('create new phone number');
+    expect(createUserProfileMock.mock.calls).toMatchSnapshot(
+      'create user profile'
+    );
+  });
+
+  it('registers a new user via their phone number, pin, and gender', async () => {
+    const query = `
+      mutation {
+        registerWithSms(
+          phoneNumber: "5133061126",
+          pin: "123456",
+          userProfile: [
+            { field: FirstName, value: "Burke" },
+            { field: LastName, value: "Shartsis" },
+            { field: Gender, value: "Male" }
+          ]
+         ) {
           token
         }
       }

--- a/packages/apollos-data-connector-rock/src/auth-sms/data-source.js
+++ b/packages/apollos-data-connector-rock/src/auth-sms/data-source.js
@@ -85,10 +85,13 @@ export default class AuthSmsDataSource extends RockApolloDataSource {
     }
 
     // Otherwise, create a new user.
-    const personAttributes = fieldsAsObject(userProfile || []);
+    const profileFields = fieldsAsObject(userProfile || []);
+    const rockUpdateFields = this.context.dataSources.Person.mapApollosFieldsToRock(
+      profileFields
+    );
     const personId = await this.context.dataSources.Auth.createUserProfile({
       email: null,
-      ...personAttributes,
+      ...rockUpdateFields,
     });
 
     // And create their phone number.

--- a/packages/apollos-data-connector-rock/src/auth/__tests__/__snapshots__/data-source.tests.js.snap
+++ b/packages/apollos-data-connector-rock/src/auth/__tests__/__snapshots__/data-source.tests.js.snap
@@ -49,6 +49,26 @@ Array [
 ]
 `;
 
+exports[`Auth should post with userProfile fields when creating a new user and map gender/birthdate 1`] = `"some-cookie"`;
+
+exports[`Auth should post with userProfile fields when creating a new user and map gender/birthdate 2`] = `
+Array [
+  Array [
+    "/People",
+    Object {
+      "BirthDay": 22,
+      "BirthMonth": 2,
+      "BirthYear": 1996,
+      "Email": "bob-jones@example.com",
+      "FirstName": "Burke",
+      "Gender": 2,
+      "IsSystem": false,
+      "LastName": "Shartsis",
+    },
+  ],
+]
+`;
+
 exports[`Auth should throw an error when creating an invalid user 1`] = `
 Array [
   Array [

--- a/packages/apollos-data-connector-rock/src/auth/__tests__/data-source.tests.js
+++ b/packages/apollos-data-connector-rock/src/auth/__tests__/data-source.tests.js
@@ -6,11 +6,12 @@ describe('Auth', () => {
 
   Date.now = jest.fn(() => 1482363367071);
 
+  const PersonDataSource = Person.dataSource;
   class AuthWithContext extends AuthDataSource {
     context = {
       rockCookie: 'some cookie',
       dataSources: {
-        Person: new Person.dataSource(),
+        Person: new PersonDataSource(),
       },
     };
   }

--- a/packages/apollos-data-connector-rock/src/auth/__tests__/data-source.tests.js
+++ b/packages/apollos-data-connector-rock/src/auth/__tests__/data-source.tests.js
@@ -52,6 +52,25 @@ describe('Auth', () => {
     expect(Auth.post.mock.calls).toMatchSnapshot();
   });
 
+  it('should post with userProfile fields when creating a new user and map gender/birthdate', async () => {
+    Auth.post = jest.fn(() => Promise.resolve());
+    Auth.createUserLogin = jest.fn(() => Promise.resolve());
+    Auth.personExists = jest.fn(() => Promise.resolve(false));
+    Auth.authenticate = jest.fn(() => Promise.resolve('some-cookie'));
+
+    const result = await Auth.registerPerson({
+      email: 'bob-jones@example.com',
+      userProfile: [
+        { field: 'FirstName', value: 'Burke ' },
+        { field: 'LastName', value: 'Shartsis ' },
+        { field: 'Gender', value: 'Female' },
+        { field: 'BirthDate', value: '1996-02-22T05:00:00.000Z' },
+      ],
+    });
+    expect(result).toMatchSnapshot();
+    expect(Auth.post.mock.calls).toMatchSnapshot();
+  });
+
   it('should throw an error when creating an invalid user', async () => {
     Auth.post = jest.fn(() => {
       throw new Error('HTTP error');

--- a/packages/apollos-data-connector-rock/src/auth/__tests__/data-source.tests.js
+++ b/packages/apollos-data-connector-rock/src/auth/__tests__/data-source.tests.js
@@ -1,4 +1,5 @@
 import AuthDataSource from '../data-source';
+import * as Person from '../../people';
 
 describe('Auth', () => {
   const tokenMock = Promise.resolve('some token');
@@ -8,6 +9,9 @@ describe('Auth', () => {
   class AuthWithContext extends AuthDataSource {
     context = {
       rockCookie: 'some cookie',
+      dataSources: {
+        Person: new Person.dataSource(),
+      },
     };
   }
   let Auth;

--- a/packages/apollos-data-connector-rock/src/auth/__tests__/index.tests.js
+++ b/packages/apollos-data-connector-rock/src/auth/__tests__/index.tests.js
@@ -5,6 +5,8 @@ import { createTestHelpers } from '@apollosproject/server-core/lib/testUtils';
 import { peopleSchema, mediaSchema } from '@apollosproject/data-schema';
 
 import * as Auth from '../index';
+import * as Person from '../../people/index';
+
 import { generateToken, registerToken } from '../token';
 
 ApollosConfig.loadJs({
@@ -14,7 +16,7 @@ ApollosConfig.loadJs({
   },
 });
 
-const { getContext, getSchema } = createTestHelpers({ Auth });
+const { getContext, getSchema } = createTestHelpers({ Auth, Person });
 
 describe('Auth', () => {
   let schema;

--- a/packages/apollos-data-connector-rock/src/auth/data-source.js
+++ b/packages/apollos-data-connector-rock/src/auth/data-source.js
@@ -110,10 +110,10 @@ export default class AuthDataSource extends RockApolloDataSource {
   createUserProfile = async ({ email, ...otherFields }) => {
     try {
       return await this.post('/People', {
+        Gender: 0, // Required by Rock. Listed first so it can be overridden by otherFields
         ...otherFields,
         Email: email,
         IsSystem: false, // Required by Rock
-        Gender: 0, // Required by Rock
       });
     } catch (err) {
       throw new Error('Unable to create profile!');
@@ -170,6 +170,7 @@ export default class AuthDataSource extends RockApolloDataSource {
       email,
       ...rockUpdateFields,
     });
+
     await this.createUserLogin({
       email,
       password,

--- a/packages/apollos-data-connector-rock/src/auth/data-source.js
+++ b/packages/apollos-data-connector-rock/src/auth/data-source.js
@@ -162,8 +162,14 @@ export default class AuthDataSource extends RockApolloDataSource {
     if (personExists) throw new Error('User already exists!');
 
     const profileFields = fieldsAsObject(userProfile || []);
+    const rockUpdateFields = this.context.dataSources.Person.mapApollosFieldsToRock(
+      profileFields
+    );
 
-    const personId = await this.createUserProfile({ email, ...profileFields });
+    const personId = await this.createUserProfile({
+      email,
+      ...rockUpdateFields,
+    });
     await this.createUserLogin({
       email,
       password,

--- a/packages/apollos-data-connector-rock/src/people/__tests__/__snapshots__/data-source.tests.js.snap
+++ b/packages/apollos-data-connector-rock/src/people/__tests__/__snapshots__/data-source.tests.js.snap
@@ -109,23 +109,6 @@ Array [
 ]
 `;
 
-exports[`Person updates a user's gender attributes 1`] = `
-Array [
-  Array [],
-]
-`;
-
-exports[`Person updates a user's gender attributes 2`] = `Array []`;
-
-exports[`Person updates a user's gender attributes 3`] = `
-Object {
-  "firstName": "Vincent",
-  "gender": 1,
-  "id": 51,
-  "lastName": "Wilson",
-}
-`;
-
 exports[`Person updates a user's gender attributes: current person 1`] = `
 Array [
   Array [],

--- a/packages/apollos-data-connector-rock/src/people/__tests__/__snapshots__/data-source.tests.js.snap
+++ b/packages/apollos-data-connector-rock/src/people/__tests__/__snapshots__/data-source.tests.js.snap
@@ -126,6 +126,23 @@ Object {
 }
 `;
 
+exports[`Person updates a user's gender attributes: current person 1`] = `
+Array [
+  Array [],
+]
+`;
+
+exports[`Person updates a user's gender attributes: result 1`] = `
+Object {
+  "firstName": "Vincent",
+  "gender": "Male",
+  "id": 51,
+  "lastName": "Wilson",
+}
+`;
+
+exports[`Person updates a user's gender attributes: rock patch 1`] = `Array []`;
+
 exports[`Person updates a user's profile attributes 1`] = `
 Array [
   Array [],

--- a/packages/apollos-data-connector-rock/src/people/__tests__/data-source.tests.js
+++ b/packages/apollos-data-connector-rock/src/people/__tests__/data-source.tests.js
@@ -146,9 +146,9 @@ describe('Person', () => {
         value: 'Male',
       },
     ]);
-    expect(result).resolves.toMatchSnapshot();
-    expect(Auth.getCurrentPerson.mock.calls).toMatchSnapshot();
-    expect(dataSource.patch.mock.calls).toMatchSnapshot();
+    expect(result).resolves.toMatchSnapshot('result');
+    expect(Auth.getCurrentPerson.mock.calls).toMatchSnapshot('current person');
+    expect(dataSource.patch.mock.calls).toMatchSnapshot('rock patch');
   });
 
   it("updates a user's birth date attributes", async () => {

--- a/packages/apollos-data-connector-rock/src/people/data-source.js
+++ b/packages/apollos-data-connector-rock/src/people/data-source.js
@@ -62,17 +62,8 @@ export default class Person extends RockApolloDataSource {
       .get();
   };
 
-  // fields is an array of objects matching the pattern
-  // [{ field: String, value: String }]
-  updateProfile = async (fields) => {
-    const currentPerson = await this.context.dataSources.Auth.getCurrentPerson();
-
-    if (!currentPerson) throw new AuthenticationError('Invalid Credentials');
-
-    // Because we have a custom enum for Gender, we do this transform prior to creating our "update object"
-    // i.e. our schema will send Gender: 1 as Gender: Male
-
-    const profileFields = fieldsAsObject(fields);
+  mapApollosFieldsToRock = (fields) => {
+    const profileFields = { ...fields };
 
     if (profileFields.Gender) {
       if (!['Unknown', 'Male', 'Female'].includes(profileFields.Gender)) {
@@ -102,6 +93,21 @@ export default class Person extends RockApolloDataSource {
       };
     }
 
+    return rockUpdateFields;
+  };
+
+  // fields is an array of objects matching the pattern
+  // [{ field: String, value: String }]
+  updateProfile = async (fields) => {
+    const currentPerson = await this.context.dataSources.Auth.getCurrentPerson();
+
+    if (!currentPerson) throw new AuthenticationError('Invalid Credentials');
+
+    const profileFields = fieldsAsObject(fields);
+    const rockUpdateFields = this.mapApollosFieldsToRock(profileFields);
+
+    // Because we have a custom enum for Gender, we do this transform prior to creating our "update object"
+    // i.e. our schema will send Gender: 1 as Gender: Male
     await this.patch(`/People/${currentPerson.id}`, rockUpdateFields);
 
     return {

--- a/packages/apollos-data-connector-rock/src/people/data-source.js
+++ b/packages/apollos-data-connector-rock/src/people/data-source.js
@@ -62,11 +62,22 @@ export default class Person extends RockApolloDataSource {
       .get();
   };
 
+  mapGender = ({ gender }) => {
+    // If the gender is coming from Rock (an int) map into the string value.
+    if (typeof gender === 'number') {
+      return Object.keys(RockGenderMap).find(
+        (key) => RockGenderMap[key] === gender
+      );
+    }
+    // Otherwise return the string value.
+    return gender;
+  };
+
   mapApollosFieldsToRock = (fields) => {
     const profileFields = { ...fields };
 
     if (profileFields.Gender) {
-      if (!['Unknown', 'Male', 'Female'].includes(profileFields.Gender)) {
+      if (!Object.keys(RockGenderMap).includes(profileFields.Gender)) {
         throw new UserInputError(
           'Rock gender must be either Unknown, Male, or Female'
         );

--- a/packages/apollos-data-connector-rock/src/people/resolver.js
+++ b/packages/apollos-data-connector-rock/src/people/resolver.js
@@ -21,12 +21,9 @@ export default {
         ? moment.tz(birthDate, ApollosConfig.ROCK.TIMEZONE).toJSON()
         : null
     ),
-    gender: enforceCurrentUser(({ gender }) => gender),
+    gender: enforceCurrentUser(({ gender }, args, { dataSources }) =>
+      dataSources.Person.mapGender({ gender })
+    ),
     email: enforceCurrentUser(({ email }) => email),
-  },
-  GENDER: {
-    Unknown: 0,
-    Male: 1,
-    Female: 2,
   },
 };

--- a/packages/apollos-data-connector-rock/src/template/data-source.tests.js
+++ b/packages/apollos-data-connector-rock/src/template/data-source.tests.js
@@ -1,6 +1,6 @@
 import { createTestHelpers } from '@apollosproject/server-core/lib/testUtils';
-import { Auth, Person } from '@apollosproject/data-connector-rock';
 import { fetch } from 'apollo-server-env';
+import { Auth, Person } from '../index';
 
 import Template from './data-source';
 


### PR DESCRIPTION
## DESCRIPTION

![image](https://user-images.githubusercontent.com/1637694/73856738-eb6b4900-4803-11ea-9aa8-2f2d99473010.png)

### What does this PR do, or why is it needed?

We are going to update the auth flow to capture Gender and Birthdate. The Gender and Birthdate fields are currently possible to provide via the schema, but they are not processed correctly. We do some processing when running the "updateFields" mutation, but we don't do that same processing when registering. This PR extracts that field processing into a seperate method, and then calls that method when both registering and updating so that the fields are mapped correctly in both places. 

This also involves changing how we handle enums, because we now want to be able to to pass either integers or strings to the GraphQL layer and have them map to the `Gender` enum directly. This involved removing the static and brittle Gender enum resolver, and replacing it with a resolver on the Person.gender field. 

### What design trade-offs/decisions were made?
n/a

### How do I test this PR?

The following queries will let you test to make sure things are working. You'll have the most luck putting your own phone number / email in instead of mine. These will only work if you don't already have data in rock (aka, userExists should return false)

```
mutation register {
  registerPerson(
    email:"vincent+02052001@differential.com",
    password:"password",
    userProfile: [{ field: FirstName, value:"Nick"}, {field: LastName, value:"Rick"}, {field: Gender, value: "Male"}, {field: BirthDate, value: "1996-02-22T05:00:00.000Z"}]
  ){
    user {
      profile {
        firstName
        lastName
        gender
        birthDate
      }
    }
  }
}

mutation requestPin {
  requestSmsLoginPin(phoneNumber: "5133061126"){
    success
  }
}

mutation registerWithSms {
  registerWithSms(
    phoneNumber:"5133061126",
    pin:"642688",
    userProfile: [{ field: FirstName, value:"Nick"}, {field: LastName, value:"Rick"}, {field: Gender, value: "Male"}, {field: BirthDate, value: "1996-02-22T05:00:00.000Z"}]
  ){
    user {
      profile {
        firstName
        lastName
         gender
        birthDate        
      }
    }
  }
}

query exists {
  userExists(identity:"vincent@differential.com")
}
```

### What automated tests did you write?

Tests over all new functionality.

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
